### PR TITLE
Change package names to valocode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,13 +7,13 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/agent/component/apiserver"
-	"github.com/verifa/bubbly/agent/component/datastore"
-	"github.com/verifa/bubbly/agent/component/natsserver"
-	"github.com/verifa/bubbly/agent/component/worker"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/agent/component/apiserver"
+	"github.com/valocode/bubbly/agent/component/datastore"
+	"github.com/valocode/bubbly/agent/component/natsserver"
+	"github.com/valocode/bubbly/agent/component/worker"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 const (

--- a/agent/component/apiserver/api_server.go
+++ b/agent/component/apiserver/api_server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/server"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/server"
 )
 
 var _ component.Component = (*APIServer)(nil)

--- a/agent/component/component.go
+++ b/agent/component/component.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 // Component provides a NATS-compatible interface for bubbly agent services.

--- a/agent/component/core.go
+++ b/agent/component/core.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 const (

--- a/agent/component/datastore/data_store.go
+++ b/agent/component/datastore/data_store.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/store"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/store"
 )
 
 var _ component.Component = (*DataStore)(nil)

--- a/agent/component/datastore/handler.go
+++ b/agent/component/datastore/handler.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // GetResourceHandler is responsible for handling subscriptions on the

--- a/agent/component/natsserver/nats.go
+++ b/agent/component/natsserver/nats.go
@@ -7,9 +7,9 @@ import (
 
 	natsd "github.com/nats-io/nats-server/server"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 const (

--- a/agent/component/subscribe.go
+++ b/agent/component/subscribe.go
@@ -3,7 +3,7 @@ package component
 import (
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 type DesiredSubscriptions []DesiredSubscription

--- a/agent/component/worker/handler.go
+++ b/agent/component/worker/handler.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/api"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // PostRunResourceHandler receives a resourceBlockJSON matching a remote run

--- a/agent/component/worker/worker.go
+++ b/agent/component/worker/worker.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/interval"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/interval"
 )
 
 const (

--- a/api/common/load.go
+++ b/api/common/load.go
@@ -3,9 +3,9 @@ package common
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
 )
 
 // LoadResourceOutput sends a ResourceOutput to the store for saving

--- a/api/common/resource.go
+++ b/api/common/resource.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
+	"github.com/valocode/bubbly/parser"
 )
 
 // RunResource takes a given resource id as string and ResourceContext, with

--- a/api/common/resource_test.go
+++ b/api/common/resource_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/api/core/data.go
+++ b/api/core/data.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"

--- a/api/core/data_test.go
+++ b/api/core/data_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/api/core/interfaces.go
+++ b/api/core/interfaces.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/verifa/bubbly/env"
+import "github.com/valocode/bubbly/env"
 
 // Resource is the interface for any resources, such as Extract, Transform,
 // etc.

--- a/api/core/resource.go
+++ b/api/core/resource.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 )
 
 const ResourceTableName = "_resource"

--- a/api/core/types.go
+++ b/api/core/types.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/events"
 )
 
 // Tasks stores a map of Task by name

--- a/api/resources.go
+++ b/api/resources.go
@@ -3,9 +3,9 @@ package api
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/core"
-	v1 "github.com/verifa/bubbly/api/v1"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	v1 "github.com/valocode/bubbly/api/v1"
+	"github.com/valocode/bubbly/env"
 )
 
 func NewParserType() *ResourcesParserType {

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -3,11 +3,11 @@ package api
 // import (
 // 	"testing"
 
-// 	"github.com/verifa/bubbly/env"
+// 	"github.com/valocode/bubbly/env"
 
 // 	"github.com/hashicorp/go-multierror"
-// 	"github.com/verifa/bubbly/api/core"
-// 	v1 "github.com/verifa/bubbly/api/v1"
+// 	"github.com/valocode/bubbly/api/core"
+// 	v1 "github.com/valocode/bubbly/api/v1"
 
 // 	"github.com/stretchr/testify/assert"
 // )

--- a/api/v1/condition.go
+++ b/api/v1/condition.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/criteria.go
+++ b/api/v1/criteria.go
@@ -3,10 +3,10 @@ package v1
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/extract.go
+++ b/api/v1/extract.go
@@ -22,10 +22,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"

--- a/api/v1/extract_test.go
+++ b/api/v1/extract_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
@@ -19,9 +19,9 @@ import (
 
 	"gopkg.in/h2non/gock.v1"
 
-	fixtureJSON "github.com/verifa/bubbly/api/v1/testdata/extract/json"
-	restGitHub0 "github.com/verifa/bubbly/api/v1/testdata/extract/rest/github"
-	fixtureXML "github.com/verifa/bubbly/api/v1/testdata/extract/xml"
+	fixtureJSON "github.com/valocode/bubbly/api/v1/testdata/extract/json"
+	restGitHub0 "github.com/valocode/bubbly/api/v1/testdata/extract/rest/github"
+	fixtureXML "github.com/valocode/bubbly/api/v1/testdata/extract/xml"
 )
 
 func TestExtractJSON(t *testing.T) {

--- a/api/v1/load.go
+++ b/api/v1/load.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
 )
 
 var _ core.Load = (*Load)(nil)

--- a/api/v1/operation.go
+++ b/api/v1/operation.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/pipeline.go
+++ b/api/v1/pipeline.go
@@ -3,10 +3,10 @@ package v1
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/query.go
+++ b/api/v1/query.go
@@ -3,14 +3,14 @@ package v1
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 var _ core.Query = (*Query)(nil)

--- a/api/v1/run.go
+++ b/api/v1/run.go
@@ -3,10 +3,10 @@ package v1
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/task.go
+++ b/api/v1/task.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/api/v1/transform.go
+++ b/api/v1/transform.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 
 	"github.com/zclconf/go-cty/cty"
 )

--- a/bubbly/apply.go
+++ b/bubbly/apply.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/verifa/bubbly/api"
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	v1 "github.com/verifa/bubbly/api/v1"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	v1 "github.com/valocode/bubbly/api/v1"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/bubbly/query.go
+++ b/bubbly/query.go
@@ -8,10 +8,10 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 )
 
 // errors

--- a/bubbly/schema.go
+++ b/bubbly/schema.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 )
 
 // Schema is the Go-native struct representation of a bubbly

--- a/client/client.go
+++ b/client/client.go
@@ -10,10 +10,10 @@ import (
 	natsd "github.com/nats-io/nats-server/server"
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/config"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/config"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 var (

--- a/client/load.go
+++ b/client/load.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // Load takes the output from a load resource and POSTs it to the Bubbly

--- a/client/nats.go
+++ b/client/nats.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 // Connect connects to a NATS server.

--- a/client/query.go
+++ b/client/query.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"github.com/nats-io/nats.go"
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
 )
 
 // Query takes the query string from a query resource spec and POSTs it

--- a/client/query_test.go
+++ b/client/query_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/client/resource.go
+++ b/client/resource.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
 )
 
 // GetResource uses the bubbly api endpoint to get a resource

--- a/client/schema.go
+++ b/client/schema.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	"github.com/verifa/bubbly/agent/component"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/agent/component"
+	"github.com/valocode/bubbly/env"
 )
 
 // PostSchema uses the bubbly api to post a schema

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/verifa/bubbly/agent"
-	"github.com/verifa/bubbly/config"
+	"github.com/valocode/bubbly/agent"
+	"github.com/valocode/bubbly/config"
 
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/verifa/bubbly/cmd/util"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/util/normalise"
+	cmdutil "github.com/valocode/bubbly/cmd/util"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/util/normalise"
 )
 
 var (

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -8,10 +8,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/verifa/bubbly/bubbly"
-	cmdutil "github.com/verifa/bubbly/cmd/util"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/util/normalise"
+	"github.com/valocode/bubbly/bubbly"
+	cmdutil "github.com/valocode/bubbly/cmd/util"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/util/normalise"
 )
 
 var (

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -8,12 +8,12 @@ import (
 	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/bubbly"
-	cmdutil "github.com/verifa/bubbly/cmd/util"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
-	"github.com/verifa/bubbly/util/normalise"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/bubbly"
+	cmdutil "github.com/valocode/bubbly/cmd/util"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
+	"github.com/valocode/bubbly/util/normalise"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,15 +3,15 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	agentCmd "github.com/verifa/bubbly/cmd/agent"
-	applyCmd "github.com/verifa/bubbly/cmd/apply"
-	getCmd "github.com/verifa/bubbly/cmd/get"
-	schemaCmd "github.com/verifa/bubbly/cmd/schema"
-	"github.com/verifa/bubbly/cmd/topics"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	agentCmd "github.com/valocode/bubbly/cmd/agent"
+	applyCmd "github.com/valocode/bubbly/cmd/apply"
+	getCmd "github.com/valocode/bubbly/cmd/get"
+	schemaCmd "github.com/valocode/bubbly/cmd/schema"
+	"github.com/valocode/bubbly/cmd/topics"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 
-	"github.com/verifa/bubbly/util/normalise"
+	"github.com/valocode/bubbly/util/normalise"
 )
 
 var (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 func TestAgentConfig(t *testing.T) {

--- a/cmd/schema/apply/apply.go
+++ b/cmd/schema/apply/apply.go
@@ -7,10 +7,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/verifa/bubbly/bubbly"
-	cmdutil "github.com/verifa/bubbly/cmd/util"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/util/normalise"
+	"github.com/valocode/bubbly/bubbly"
+	cmdutil "github.com/valocode/bubbly/cmd/util"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/util/normalise"
 )
 
 var (

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -3,8 +3,8 @@ package schema
 import (
 	"github.com/spf13/cobra"
 
-	schemaApplyCmd "github.com/verifa/bubbly/cmd/schema/apply"
-	"github.com/verifa/bubbly/env"
+	schemaApplyCmd "github.com/valocode/bubbly/cmd/schema/apply"
+	"github.com/valocode/bubbly/env"
 )
 
 // NewCmdGet creates a new cobra.Command representing "bubbly schema"

--- a/env/context.go
+++ b/env/context.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog"
-	"github.com/verifa/bubbly/config"
+	"github.com/valocode/bubbly/config"
 )
 
 // BubblyContext holds global bubbly state that is required to be injected into

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/verifa/bubbly
+module github.com/valocode/bubbly
 
 go 1.15
 

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/bubbly"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
-	integration "github.com/verifa/bubbly/integration/testdata"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/bubbly"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
+	integration "github.com/valocode/bubbly/integration/testdata"
 )
 
 func testGet(t *testing.T, bCtx *env.BubblyContext, args []string) {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/rs/zerolog"
 
-	schemaApplyCmd "github.com/verifa/bubbly/cmd/schema/apply"
-	"github.com/verifa/bubbly/env"
+	schemaApplyCmd "github.com/valocode/bubbly/cmd/schema/apply"
+	"github.com/valocode/bubbly/env"
 )
 
 func TestMain(m *testing.M) {

--- a/integration/query_test.go
+++ b/integration/query_test.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/bubbly"
-	"github.com/verifa/bubbly/client"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/bubbly"
+	"github.com/valocode/bubbly/client"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 func eventQuery(t *testing.T, bCtx *env.BubblyContext) {

--- a/integration/testdata/test_helper.go
+++ b/integration/testdata/test_helper.go
@@ -8,10 +8,10 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/cmd/get"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/cmd/get"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/integration/testdata/testautomation/golang/test-report.json
+++ b/integration/testdata/testautomation/golang/test-report.json
@@ -2,5037 +2,5037 @@
     {
         "Time": "2020-12-02T19:53:11.128291+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources"
     },
     {
         "Time": "2020-12-02T19:53:11.129125+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources",
         "Output": "=== RUN   TestNewResources\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129159+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources",
         "Output": "=== PAUSE TestNewResources\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129172+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources"
     },
     {
         "Time": "2020-12-02T19:53:11.129184+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks"
     },
     {
         "Time": "2020-12-02T19:53:11.129195+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks",
         "Output": "=== RUN   TestNewResourcesFromBlocks\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129211+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks",
         "Output": "=== PAUSE TestNewResourcesFromBlocks\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129241+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks"
     },
     {
         "Time": "2020-12-02T19:53:11.129264+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource"
     },
     {
         "Time": "2020-12-02T19:53:11.129297+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource",
         "Output": "=== RUN   TestGetResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129358+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource",
         "Output": "=== PAUSE TestGetResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129374+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource"
     },
     {
         "Time": "2020-12-02T19:53:11.129417+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails"
     },
     {
         "Time": "2020-12-02T19:53:11.129433+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails",
         "Output": "=== RUN   TestNewResourceFails\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129451+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails",
         "Output": "=== PAUSE TestNewResourceFails\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129464+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails"
     },
     {
         "Time": "2020-12-02T19:53:11.129475+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources"
     },
     {
         "Time": "2020-12-02T19:53:11.129486+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources",
         "Output": "=== CONT  TestNewResources\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129497+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources/base_set_up_of_NewResources"
     },
     {
         "Time": "2020-12-02T19:53:11.129513+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources/base_set_up_of_NewResources",
         "Output": "=== RUN   TestNewResources/base_set_up_of_NewResources\n"
     },
     {
         "Time": "2020-12-02T19:53:11.12975+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources",
         "Output": "--- PASS: TestNewResources (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129776+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources/base_set_up_of_NewResources",
         "Output": "    --- PASS: TestNewResources/base_set_up_of_NewResources (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129794+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources/base_set_up_of_NewResources",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.129818+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResources",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.12983+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails"
     },
     {
         "Time": "2020-12-02T19:53:11.129842+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails",
         "Output": "=== CONT  TestNewResourceFails\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129886+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_duplicate_resource_creation"
     },
     {
         "Time": "2020-12-02T19:53:11.129897+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_duplicate_resource_creation",
         "Output": "=== RUN   TestNewResourceFails/basic_duplicate_resource_creation\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129913+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_unsupported_resource_creation"
     },
     {
         "Time": "2020-12-02T19:53:11.129922+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_unsupported_resource_creation",
         "Output": "=== RUN   TestNewResourceFails/basic_unsupported_resource_creation\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129933+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails",
         "Output": "--- PASS: TestNewResourceFails (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129943+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_duplicate_resource_creation",
         "Output": "    --- PASS: TestNewResourceFails/basic_duplicate_resource_creation (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129955+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_duplicate_resource_creation",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.12997+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_unsupported_resource_creation",
         "Output": "    --- PASS: TestNewResourceFails/basic_unsupported_resource_creation (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.129986+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails/basic_unsupported_resource_creation",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.129995+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourceFails",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130002+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks"
     },
     {
         "Time": "2020-12-02T19:53:11.130009+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks",
         "Output": "=== CONT  TestNewResourcesFromBlocks\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130017+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.130024+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_extract",
         "Output": "=== RUN   TestNewResourcesFromBlocks/basic_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130031+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_extract",
         "Output": "    resources_test.go:180: resources: \u0026map[extract:map[sonarqube:v1.default.extract.sonarqube] load:map[] pipeline:map[] pipeline_run:map[] transform:map[]]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130045+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_all_resource_types"
     },
     {
         "Time": "2020-12-02T19:53:11.130052+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_all_resource_types",
         "Output": "=== RUN   TestNewResourcesFromBlocks/basic_all_resource_types\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130059+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_all_resource_types",
         "Output": "    resources_test.go:180: resources: \u0026map[extract:map[sonarqube:v1.default.extract.sonarqube] load:map[sonarqube:v1.default.load.sonarqube] pipeline:map[sonarqube:v1.default.pipeline.sonarqube] pipeline_run:map[sonarqube:v1.default.pipeline_run.sonarqube] transform:map[sonarqube:v1.default.transform.sonarqube]]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130085+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks",
         "Output": "--- PASS: TestNewResourcesFromBlocks (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130148+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_extract",
         "Output": "    --- PASS: TestNewResourcesFromBlocks/basic_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130181+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130191+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_all_resource_types",
         "Output": "    --- PASS: TestNewResourcesFromBlocks/basic_all_resource_types (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.1302+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks/basic_all_resource_types",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130208+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestNewResourcesFromBlocks",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130215+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource"
     },
     {
         "Time": "2020-12-02T19:53:11.130222+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource",
         "Output": "=== CONT  TestGetResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.13023+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_Get"
     },
     {
         "Time": "2020-12-02T19:53:11.130237+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_Get",
         "Output": "=== RUN   TestGetResource/basic_Get\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130245+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_unsuccessful_Get"
     },
     {
         "Time": "2020-12-02T19:53:11.130253+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_unsuccessful_Get",
         "Output": "=== RUN   TestGetResource/basic_unsuccessful_Get\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130261+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource",
         "Output": "--- PASS: TestGetResource (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130272+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_Get",
         "Output": "    --- PASS: TestGetResource/basic_Get (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.13028+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_Get",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130288+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_unsuccessful_Get",
         "Output": "    --- PASS: TestGetResource/basic_unsuccessful_Get (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130296+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource/basic_unsuccessful_Get",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130304+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Test": "TestGetResource",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.130312+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130325+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api",
-        "Output": "ok  \tgithub.com/verifa/bubbly/api\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/api",
+        "Output": "ok  \tgithub.com/valocode/bubbly/api\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.130342+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api",
+        "Package": "github.com/valocode/bubbly/api",
         "Elapsed": 0.004
     },
     {
         "Time": "2020-12-02T19:53:11.168919+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestJSONData"
     },
     {
         "Time": "2020-12-02T19:53:11.168992+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestJSONData",
         "Output": "=== RUN   TestJSONData\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169007+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestJSONData",
         "Output": "    data_test.go:39: Transform JSON() returned: [{\"table\":\"TestTable\",\"fields\":[{\"name\":\"TestField\",\"Value\":{\"attribute\":{\"nested\":\"some value\"}}}],\"data\":null}]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169076+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestJSONData",
         "Output": "--- PASS: TestJSONData (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169124+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestJSONData",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169165+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock"
     },
     {
         "Time": "2020-12-02T19:53:11.169176+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock",
         "Output": "=== RUN   TestReadHCLToResourceBlock\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169206+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock",
         "Output": "=== PAUSE TestReadHCLToResourceBlock\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169215+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock"
     },
     {
         "Time": "2020-12-02T19:53:11.169222+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString"
     },
     {
         "Time": "2020-12-02T19:53:11.169229+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString",
         "Output": "=== RUN   TestResourceBlockString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169243+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString",
         "Output": "=== PAUSE TestResourceBlockString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.16925+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString"
     },
     {
         "Time": "2020-12-02T19:53:11.169257+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels"
     },
     {
         "Time": "2020-12-02T19:53:11.169264+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels",
         "Output": "=== RUN   TestResourceBlockLabels\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169272+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels",
         "Output": "=== PAUSE TestResourceBlockLabels\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169279+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels"
     },
     {
         "Time": "2020-12-02T19:53:11.169287+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString"
     },
     {
         "Time": "2020-12-02T19:53:11.169294+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString",
         "Output": "=== RUN   TestNewResourceIDFromString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169302+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString",
         "Output": "=== PAUSE TestNewResourceIDFromString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169309+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString"
     },
     {
         "Time": "2020-12-02T19:53:11.169316+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString"
     },
     {
         "Time": "2020-12-02T19:53:11.169324+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString",
         "Output": "=== RUN   TestString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169332+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString",
         "Output": "=== PAUSE TestString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169339+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString"
     },
     {
         "Time": "2020-12-02T19:53:11.169346+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestIssueTable"
     },
     {
         "Time": "2020-12-02T19:53:11.169389+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestIssueTable",
         "Output": "=== RUN   TestIssueTable\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169399+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestIssueTable",
         "Output": "    table_test.go:110: Is there a test needed here for table linter_issue?\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169412+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestIssueTable",
         "Output": "--- PASS: TestIssueTable (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169438+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestIssueTable",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169447+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput"
     },
     {
         "Time": "2020-12-02T19:53:11.169455+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput",
         "Output": "=== RUN   TestOutput\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169463+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput/basic_Output"
     },
     {
         "Time": "2020-12-02T19:53:11.169473+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput/basic_Output",
         "Output": "=== RUN   TestOutput/basic_Output\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169482+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput",
         "Output": "--- PASS: TestOutput (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169491+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput/basic_Output",
         "Output": "    --- PASS: TestOutput/basic_Output (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169584+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput/basic_Output",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169601+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestOutput",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169609+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference"
     },
     {
         "Time": "2020-12-02T19:53:11.169616+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference",
         "Output": "=== RUN   TestReference\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169624+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference/basic_local_block"
     },
     {
         "Time": "2020-12-02T19:53:11.169631+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference/basic_local_block",
         "Output": "=== RUN   TestReference/basic_local_block\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169645+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference",
         "Output": "--- PASS: TestReference (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169655+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference/basic_local_block",
         "Output": "    --- PASS: TestReference/basic_local_block (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169664+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference/basic_local_block",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169674+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReference",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169682+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock"
     },
     {
         "Time": "2020-12-02T19:53:11.169689+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock",
         "Output": "=== CONT  TestReadHCLToResourceBlock\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169697+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock/basic_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.169705+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock/basic_extract",
         "Output": "=== RUN   TestReadHCLToResourceBlock/basic_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169713+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString"
     },
     {
         "Time": "2020-12-02T19:53:11.16972+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString",
         "Output": "=== CONT  TestNewResourceIDFromString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169728+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_extract_without_namespace_specified"
     },
     {
         "Time": "2020-12-02T19:53:11.169753+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_extract_without_namespace_specified",
         "Output": "=== RUN   TestNewResourceIDFromString/basic_extract_without_namespace_specified\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169765+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_extract_without_namespace_specified",
         "Output": "    resource_test.go:224: Resource ID: /extract/sonarqube\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169773+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_pipeline_with_namespace_specified"
     },
     {
         "Time": "2020-12-02T19:53:11.169781+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_pipeline_with_namespace_specified",
         "Output": "=== RUN   TestNewResourceIDFromString/basic_pipeline_with_namespace_specified\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169789+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_pipeline_with_namespace_specified",
         "Output": "    resource_test.go:224: Resource ID: qa/pipeline/sonarqube\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169797+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString",
         "Output": "--- PASS: TestNewResourceIDFromString (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169806+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_extract_without_namespace_specified",
         "Output": "    --- PASS: TestNewResourceIDFromString/basic_extract_without_namespace_specified (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169818+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_extract_without_namespace_specified",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169826+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_pipeline_with_namespace_specified",
         "Output": "    --- PASS: TestNewResourceIDFromString/basic_pipeline_with_namespace_specified (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169834+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString/basic_pipeline_with_namespace_specified",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169841+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestNewResourceIDFromString",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169848+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString"
     },
     {
         "Time": "2020-12-02T19:53:11.169856+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString",
         "Output": "=== CONT  TestString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169864+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.169877+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_extract",
         "Output": "=== RUN   TestString/basic_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169886+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_pipeline"
     },
     {
         "Time": "2020-12-02T19:53:11.169893+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_pipeline",
         "Output": "=== RUN   TestString/basic_pipeline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169901+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString",
         "Output": "--- PASS: TestString (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169909+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_extract",
         "Output": "    --- PASS: TestString/basic_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169917+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169939+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_pipeline",
         "Output": "    --- PASS: TestString/basic_pipeline (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169948+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString/basic_pipeline",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169956+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestString",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.169964+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels"
     },
     {
         "Time": "2020-12-02T19:53:11.169971+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels",
         "Output": "=== CONT  TestResourceBlockLabels\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169979+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.169988+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract",
         "Output": "=== RUN   TestResourceBlockLabels/basic_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.169996+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_labels"
     },
     {
         "Time": "2020-12-02T19:53:11.170011+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_labels",
         "Output": "=== RUN   TestResourceBlockLabels/basic_extract_without_labels\n"
     },
     {
         "Time": "2020-12-02T19:53:11.17002+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_metadata"
     },
     {
         "Time": "2020-12-02T19:53:11.170028+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_metadata",
         "Output": "=== RUN   TestResourceBlockLabels/basic_extract_without_metadata\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170037+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels",
         "Output": "--- PASS: TestResourceBlockLabels (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170046+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract",
         "Output": "    --- PASS: TestResourceBlockLabels/basic_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170062+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.17007+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_labels",
         "Output": "    --- PASS: TestResourceBlockLabels/basic_extract_without_labels (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.17008+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_labels",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170088+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_metadata",
         "Output": "    --- PASS: TestResourceBlockLabels/basic_extract_without_metadata (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170096+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels/basic_extract_without_metadata",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170103+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockLabels",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.17011+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString"
     },
     {
         "Time": "2020-12-02T19:53:11.170122+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString",
         "Output": "=== CONT  TestResourceBlockString\n"
     },
     {
         "Time": "2020-12-02T19:53:11.17013+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.170151+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract",
         "Output": "=== RUN   TestResourceBlockString/basic_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170159+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_namespace"
     },
     {
         "Time": "2020-12-02T19:53:11.170166+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_namespace",
         "Output": "=== RUN   TestResourceBlockString/basic_extract_without_namespace\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170175+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_metadata"
     },
     {
         "Time": "2020-12-02T19:53:11.170182+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_metadata",
         "Output": "=== RUN   TestResourceBlockString/basic_extract_without_metadata\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170193+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString",
         "Output": "--- PASS: TestResourceBlockString (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170201+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract",
         "Output": "    --- PASS: TestResourceBlockString/basic_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.17021+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170219+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_namespace",
         "Output": "    --- PASS: TestResourceBlockString/basic_extract_without_namespace (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170227+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_namespace",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170235+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_metadata",
         "Output": "    --- PASS: TestResourceBlockString/basic_extract_without_metadata (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170242+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString/basic_extract_without_metadata",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.17025+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestResourceBlockString",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170258+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock",
         "Output": "--- PASS: TestReadHCLToResourceBlock (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170265+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock/basic_extract",
         "Output": "    --- PASS: TestReadHCLToResourceBlock/basic_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170272+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock/basic_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170279+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Test": "TestReadHCLToResourceBlock",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.170286+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170294+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/core",
-        "Output": "ok  \tgithub.com/verifa/bubbly/api/core\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/api/core",
+        "Output": "ok  \tgithub.com/valocode/bubbly/api/core\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.170309+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/core",
+        "Package": "github.com/valocode/bubbly/api/core",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.182371+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup"
     },
     {
         "Time": "2020-12-02T19:53:11.182601+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup",
         "Output": "=== RUN   TestClientSetup\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182654+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/basic_valid_config.ServerConfig"
     },
     {
         "Time": "2020-12-02T19:53:11.182665+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/basic_valid_config.ServerConfig",
         "Output": "=== RUN   TestClientSetup/basic_valid_config.ServerConfig\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182676+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/empty_config.ServerConfig"
     },
     {
         "Time": "2020-12-02T19:53:11.182686+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/empty_config.ServerConfig",
         "Output": "=== RUN   TestClientSetup/empty_config.ServerConfig\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182704+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup",
         "Output": "--- PASS: TestClientSetup (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182718+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/basic_valid_config.ServerConfig",
         "Output": "    --- PASS: TestClientSetup/basic_valid_config.ServerConfig (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182728+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/basic_valid_config.ServerConfig",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182738+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/empty_config.ServerConfig",
         "Output": "    --- SKIP: TestClientSetup/empty_config.ServerConfig (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182746+02:00",
         "Action": "skip",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup/empty_config.ServerConfig",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182754+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestClientSetup",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182761+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources"
     },
     {
         "Time": "2020-12-02T19:53:11.182769+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources",
         "Output": "=== RUN   TestSuggestBubblyResources\n"
     },
     {
         "Time": "2020-12-02T19:53:11.18278+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources/basic"
     },
     {
         "Time": "2020-12-02T19:53:11.182788+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources/basic",
         "Output": "=== RUN   TestSuggestBubblyResources/basic\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182796+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources",
         "Output": "--- PASS: TestSuggestBubblyResources (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182805+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources/basic",
         "Output": "    --- PASS: TestSuggestBubblyResources/basic (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182813+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources/basic",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.18282+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestSuggestBubblyResources",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182828+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf"
     },
     {
         "Time": "2020-12-02T19:53:11.182835+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf",
         "Output": "=== RUN   TestUsageErrorf\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182844+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf/basic"
     },
     {
         "Time": "2020-12-02T19:53:11.182851+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf/basic",
         "Output": "=== RUN   TestUsageErrorf/basic\n"
     },
     {
         "Time": "2020-12-02T19:53:11.18286+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf",
         "Output": "--- PASS: TestUsageErrorf (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182937+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf/basic",
         "Output": "    --- PASS: TestUsageErrorf/basic (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182964+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf/basic",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182975+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Test": "TestUsageErrorf",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.182989+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.182999+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd/util",
-        "Output": "ok  \tgithub.com/verifa/bubbly/cmd/util\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/cmd/util",
+        "Output": "ok  \tgithub.com/valocode/bubbly/cmd/util\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.183032+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd/util",
+        "Package": "github.com/valocode/bubbly/cmd/util",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.190901+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply"
     },
     {
         "Time": "2020-12-02T19:53:11.190982+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply",
         "Output": "=== RUN   TestApply\n"
     },
     {
         "Time": "2020-12-02T19:53:11.191013+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube"
     },
     {
         "Time": "2020-12-02T19:53:11.191025+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "=== RUN   TestApply/sonarqube\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192176+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Processing pipeline_run v1.default.pipeline_run.sonarqube\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.19222+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Applying task: extract_sonarqube\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192235+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "body: \u0026{0xc0001abe40 0xc0003544c0 \u003cnil\u003e map[] map[]}\ttask: extract_sonarqube\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192257+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Applying task: extract_git\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192264+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "body: \u0026{0xc000334000 0xc000354500 \u003cnil\u003e map[] map[]}\ttask: extract_git\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192269+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Local branch: dev\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192274+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Local branch: master\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192279+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f refs/heads/dev\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.1923+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"81411ea85f68f64f727f140400d7107786d93ba4 refs/heads/master\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192305+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f refs/tags/gruffalo\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.19233+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"81411ea85f68f64f727f140400d7107786d93ba4 refs/tags/kawabunga\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192337+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"ref: refs/heads/master HEAD\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192343+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"short name\":\"gruffalo\",\"hash\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Found tag:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192349+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"short name\":\"kawabunga\",\"hash\":\"81411ea85f68f64f727f140400d7107786d93ba4\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Found tag:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.19241+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Applying task: transform\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192444+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "body: \u0026{0xc000334210 0xc000354520 \u003cnil\u003e map[] map[]}\ttask: transform\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192472+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Applying task: load\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192486+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "body: \u0026{0xc000334370 0xc000354540 \u003cnil\u003e map[] map[]}\ttask: load\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192498+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Attempting to load this JSON: [{\\\"table\\\":\\\"repository_version\\\",\\\"fields\\\":[{\\\"name\\\":\\\"Commit\\\",\\\"Value\\\":\\\"81411ea85f68f64f727f140400d7107786d93ba4\\\"},{\\\"name\\\":\\\"Tag\\\",\\\"Value\\\":\\\"kawabunga\\\"},{\\\"name\\\":\\\"Branch\\\",\\\"Value\\\":\\\"master\\\"}],\\\"data\\\":null},{\\\"table\\\":\\\"linter_issue\\\",\\\"fields\\\":[{\\\"name\\\":\\\"Severity\\\",\\\"Value\\\":\\\"BLOCKER\\\"},{\\\"name\\\":\\\"Name\\\",\\\"Value\\\":\\\"fully-fleshed issue\\\"},{\\\"name\\\":\\\"Type\\\",\\\"Value\\\":\\\"CODE_SMELL\\\"}],\\\"data\\\":null},{\\\"table\\\":\\\"linter_issue\\\",\\\"fields\\\":[{\\\"name\\\":\\\"Severity\\\",\\\"Value\\\":\\\"INFO\\\"},{\\\"name\\\":\\\"Name\\\",\\\"Value\\\":\\\"minimal issue raised at file level\\\"},{\\\"name\\\":\\\"Type\\\",\\\"Value\\\":\\\"BUG\\\"}],\\\"data\\\":null}]\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192533+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"cfg\":{\"Protocol\":\"http\",\"Port\":\"8080\",\"Host\":\"localhost\",\"Auth\":false,\"Token\":\"\"},\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"loading with config\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192546+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"info\",\"url\":\"http://localhost:8080\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"custom bubbly host set\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192575+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"data\":{\"data\":[{\"table\":\"repository_version\",\"fields\":[{\"name\":\"Commit\",\"Value\":\"81411ea85f68f64f727f140400d7107786d93ba4\"},{\"name\":\"Tag\",\"Value\":\"kawabunga\"},{\"name\":\"Branch\",\"Value\":\"master\"}],\"data\":null},{\"table\":\"linter_issue\",\"fields\":[{\"name\":\"Severity\",\"Value\":\"BLOCKER\"},{\"name\":\"Name\",\"Value\":\"fully-fleshed issue\"},{\"name\":\"Type\",\"Value\":\"CODE_SMELL\"}],\"data\":null},{\"table\":\"linter_issue\",\"fields\":[{\"name\":\"Severity\",\"Value\":\"INFO\"},{\"name\":\"Name\",\"Value\":\"minimal issue raised at file level\"},{\"name\":\"Type\",\"Value\":\"BUG\"}],\"data\":null}]},\"host\":\"http://localhost:8080\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Making POST to Bubbly server from client.Load to load data.\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192594+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"JSON successfully loaded to bubbly server\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192611+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply",
         "Output": "--- PASS: TestApply (0.01s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192626+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Output": "    --- PASS: TestApply/sonarqube (0.01s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192639+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply/sonarqube",
         "Elapsed": 0.01
     },
     {
         "Time": "2020-12-02T19:53:11.192656+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Test": "TestApply",
         "Elapsed": 0.01
     },
     {
         "Time": "2020-12-02T19:53:11.192666+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192675+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/bubbly",
-        "Output": "ok  \tgithub.com/verifa/bubbly/bubbly\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/bubbly",
+        "Output": "ok  \tgithub.com/valocode/bubbly/bubbly\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.192688+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/bubbly",
+        "Package": "github.com/valocode/bubbly/bubbly",
         "Elapsed": 0.002
     },
     {
         "Time": "2020-12-02T19:53:11.194975+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Test": "TestMergo"
     },
     {
         "Time": "2020-12-02T19:53:11.195005+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Test": "TestMergo",
         "Output": "=== RUN   TestMergo\n"
     },
     {
         "Time": "2020-12-02T19:53:11.195042+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Test": "TestMergo",
         "Output": "{two 0xc0001289c0}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.19508+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Test": "TestMergo",
         "Output": "--- PASS: TestMergo (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.195091+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Test": "TestMergo",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.195102+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.195111+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/integration",
-        "Output": "ok  \tgithub.com/verifa/bubbly/integration\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/integration",
+        "Output": "ok  \tgithub.com/valocode/bubbly/integration\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.195127+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/integration",
+        "Package": "github.com/valocode/bubbly/integration",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203076+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig"
     },
     {
         "Time": "2020-12-02T19:53:11.203117+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig",
         "Output": "=== RUN   TestNewConfig\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203136+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings"
     },
     {
         "Time": "2020-12-02T19:53:11.203147+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings",
         "Output": "=== RUN   TestNewConfig/basic_creation_of_Config_from_viper_bindings\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203185+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults"
     },
     {
         "Time": "2020-12-02T19:53:11.203234+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Output": "=== RUN   TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203272+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings"
     },
     {
         "Time": "2020-12-02T19:53:11.203285+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings",
         "Output": "=== RUN   TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings\n"
     },
     {
         "Time": "2020-12-02T19:53:11.2033+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig",
         "Output": "--- PASS: TestNewConfig (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203316+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings",
         "Output": "    --- PASS: TestNewConfig/basic_creation_of_Config_from_viper_bindings (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203327+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203338+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Output": "    --- PASS: TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203374+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203389+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings",
         "Output": "    --- PASS: TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203397+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig/basic_creation_of_Config_from_limited_viper_bindings",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203404+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewConfig",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203413+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs"
     },
     {
         "Time": "2020-12-02T19:53:11.20342+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs",
         "Output": "=== RUN   TestSetupConfigs\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203428+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs",
         "Output": "=== PAUSE TestSetupConfigs\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203435+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs"
     },
     {
         "Time": "2020-12-02T19:53:11.203443+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig"
     },
     {
         "Time": "2020-12-02T19:53:11.20345+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig",
         "Output": "=== RUN   TestNewDefaultConfig\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203457+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig/basic_creation_of_Config_from_defaults"
     },
     {
         "Time": "2020-12-02T19:53:11.203464+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig/basic_creation_of_Config_from_defaults",
         "Output": "=== RUN   TestNewDefaultConfig/basic_creation_of_Config_from_defaults\n"
     },
     {
         "Time": "2020-12-02T19:53:11.20349+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig",
         "Output": "--- PASS: TestNewDefaultConfig (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203501+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig/basic_creation_of_Config_from_defaults",
         "Output": "    --- PASS: TestNewDefaultConfig/basic_creation_of_Config_from_defaults (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203509+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig/basic_creation_of_Config_from_defaults",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203518+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestNewDefaultConfig",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.20353+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs"
     },
     {
         "Time": "2020-12-02T19:53:11.203537+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs",
         "Output": "=== CONT  TestSetupConfigs\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203545+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings"
     },
     {
         "Time": "2020-12-02T19:53:11.203552+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings",
         "Output": "=== RUN   TestSetupConfigs/basic_creation_of_Config_from_viper_bindings\n"
     },
     {
         "Time": "2020-12-02T19:53:11.20356+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults"
     },
     {
         "Time": "2020-12-02T19:53:11.203567+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Output": "=== RUN   TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203575+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01"
     },
     {
         "Time": "2020-12-02T19:53:11.203582+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01",
         "Output": "=== RUN   TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01\n"
     },
     {
         "Time": "2020-12-02T19:53:11.20359+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs",
         "Output": "--- PASS: TestSetupConfigs (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203598+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings",
         "Output": "    --- PASS: TestSetupConfigs/basic_creation_of_Config_from_viper_bindings (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203608+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203616+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Output": "    --- PASS: TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203625+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203633+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01",
         "Output": "    --- PASS: TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01 (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.20364+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.20366+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Test": "TestSetupConfigs",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.203669+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203676+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/config",
-        "Output": "ok  \tgithub.com/verifa/bubbly/config\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/config",
+        "Output": "ok  \tgithub.com/valocode/bubbly/config\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.203692+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/config",
+        "Package": "github.com/valocode/bubbly/config",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.214084+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource"
     },
     {
         "Time": "2020-12-02T19:53:11.214115+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource",
         "Output": "=== RUN   TestDescribeResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214125+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe"
     },
     {
         "Time": "2020-12-02T19:53:11.214131+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe",
         "Output": "=== RUN   TestDescribeResource/basic_extract_resource_describe\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214136+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe",
         "Output": "{\"level\":\"info\",\"url\":\"http://localhost:8080\",\"time\":\"2020-12-02T16:20:19+02:00\",\"message\":\"custom bubbly host set\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214148+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe",
         "Output": "{\"level\":\"debug\",\"route\":\"http://localhost:8080/describe/extract/v1/example_extract\",\"time\":\"2020-12-02T16:20:19+02:00\",\"message\":\"attempting to describe resource via GET request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214167+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource",
         "Output": "--- PASS: TestDescribeResource (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214177+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe",
         "Output": "    --- PASS: TestDescribeResource/basic_extract_resource_describe (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214186+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource/basic_extract_resource_describe",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.214196+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResource",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.214206+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup"
     },
     {
         "Time": "2020-12-02T19:53:11.214214+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup",
         "Output": "=== RUN   TestDescribeResourceGroup\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214221+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe"
     },
     {
         "Time": "2020-12-02T19:53:11.214229+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe",
         "Output": "=== RUN   TestDescribeResourceGroup/basic_extract_resource_group_describe\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214239+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe",
         "Output": "{\"level\":\"info\",\"url\":\"http://localhost:8080\",\"time\":\"2020-12-02T16:20:19+02:00\",\"message\":\"custom bubbly host set\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214257+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe",
         "Output": "{\"level\":\"debug\",\"route\":\"http://localhost:8080/describe/extract/v1\",\"time\":\"2020-12-02T16:20:19+02:00\",\"message\":\"attempting to describe resource group via GET request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214287+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup",
         "Output": "--- PASS: TestDescribeResourceGroup (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214298+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe",
         "Output": "    --- PASS: TestDescribeResourceGroup/basic_extract_resource_group_describe (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214306+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup/basic_extract_resource_group_describe",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.214313+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Test": "TestDescribeResourceGroup",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.214321+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214328+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/client",
-        "Output": "ok  \tgithub.com/verifa/bubbly/client\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/client",
+        "Output": "ok  \tgithub.com/valocode/bubbly/client\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.214344+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/client",
+        "Package": "github.com/valocode/bubbly/client",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218423+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc"
     },
     {
         "Time": "2020-12-02T19:53:11.218454+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc",
         "Output": "=== RUN   TestLongDesc\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218479+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/basic"
     },
     {
         "Time": "2020-12-02T19:53:11.218488+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/basic",
         "Output": "=== RUN   TestLongDesc/basic\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218496+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/empty_string"
     },
     {
         "Time": "2020-12-02T19:53:11.218503+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/empty_string",
         "Output": "=== RUN   TestLongDesc/empty_string\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218513+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc",
         "Output": "--- PASS: TestLongDesc (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218524+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/basic",
         "Output": "    --- PASS: TestLongDesc/basic (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.21854+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/basic",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.21855+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/empty_string",
         "Output": "    --- PASS: TestLongDesc/empty_string (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218563+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc/empty_string",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218571+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestLongDesc",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218577+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples"
     },
     {
         "Time": "2020-12-02T19:53:11.218588+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples",
         "Output": "=== RUN   TestExamples\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218597+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic"
     },
     {
         "Time": "2020-12-02T19:53:11.218605+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic",
         "Output": "=== RUN   TestExamples/basic\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218631+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/empty_string"
     },
     {
         "Time": "2020-12-02T19:53:11.218639+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/empty_string",
         "Output": "=== RUN   TestExamples/empty_string\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218648+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic_with_explicit_trim"
     },
     {
         "Time": "2020-12-02T19:53:11.218656+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic_with_explicit_trim",
         "Output": "=== RUN   TestExamples/basic_with_explicit_trim\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218668+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples",
         "Output": "--- PASS: TestExamples (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218677+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic",
         "Output": "    --- PASS: TestExamples/basic (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218685+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218693+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/empty_string",
         "Output": "    --- PASS: TestExamples/empty_string (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218702+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/empty_string",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.21871+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic_with_explicit_trim",
         "Output": "    --- PASS: TestExamples/basic_with_explicit_trim (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218719+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples/basic_with_explicit_trim",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218726+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Test": "TestExamples",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.218733+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.21874+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/util/normalise",
-        "Output": "ok  \tgithub.com/verifa/bubbly/util/normalise\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/util/normalise",
+        "Output": "ok  \tgithub.com/valocode/bubbly/util/normalise\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.218751+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/util/normalise",
+        "Package": "github.com/valocode/bubbly/util/normalise",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221061+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON"
     },
     {
         "Time": "2020-12-02T19:53:11.221083+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON",
         "Output": "=== RUN   TestExtractJSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221091+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON/sonarqube-example"
     },
     {
         "Time": "2020-12-02T19:53:11.221097+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON/sonarqube-example",
         "Output": "=== RUN   TestExtractJSON/sonarqube-example\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221104+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON",
         "Output": "--- PASS: TestExtractJSON (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22111+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON/sonarqube-example",
         "Output": "    --- PASS: TestExtractJSON/sonarqube-example (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221119+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON/sonarqube-example",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221126+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractJSON",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221131+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML"
     },
     {
         "Time": "2020-12-02T19:53:11.221173+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML",
         "Output": "=== RUN   TestExtractXML\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22119+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit0"
     },
     {
         "Time": "2020-12-02T19:53:11.221197+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit0",
         "Output": "=== RUN   TestExtractXML/junit0\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221202+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit1"
     },
     {
         "Time": "2020-12-02T19:53:11.221206+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit1",
         "Output": "=== RUN   TestExtractXML/junit1\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221211+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit2"
     },
     {
         "Time": "2020-12-02T19:53:11.221216+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit2",
         "Output": "=== RUN   TestExtractXML/junit2\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221246+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML",
         "Output": "--- PASS: TestExtractXML (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221254+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit0",
         "Output": "    --- PASS: TestExtractXML/junit0 (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221259+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit0",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221279+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit1",
         "Output": "    --- PASS: TestExtractXML/junit1 (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221284+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit1",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221289+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit2",
         "Output": "    --- PASS: TestExtractXML/junit2 (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221294+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML/junit2",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221298+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractXML",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221303+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit"
     },
     {
         "Time": "2020-12-02T19:53:11.221314+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "=== RUN   TestExtractGit\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22132+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Local branch: dev\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221356+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Local branch: master\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221368+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f refs/heads/dev\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221383+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"81411ea85f68f64f727f140400d7107786d93ba4 refs/heads/master\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221392+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f refs/tags/gruffalo\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221459+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"81411ea85f68f64f727f140400d7107786d93ba4 refs/tags/kawabunga\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221488+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"ref.String()\":\"ref: refs/heads/master HEAD\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Reference not a remote:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221507+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"short name\":\"gruffalo\",\"hash\":\"20d68b2bc03a8fe39e84160bf69dc7b476df547f\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Found tag:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221518+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "{\"level\":\"debug\",\"short name\":\"kawabunga\",\"hash\":\"81411ea85f68f64f727f140400d7107786d93ba4\",\"time\":\"2020-12-02T16:20:20+02:00\",\"message\":\"Found tag:\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22153+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Output": "--- PASS: TestExtractGit (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221544+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractGit",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.221558+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBaseline"
     },
     {
         "Time": "2020-12-02T19:53:11.221566+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBaseline",
         "Output": "=== RUN   TestExtractRestBaseline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22158+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBaseline",
         "Output": "--- PASS: TestExtractRestBaseline (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.221593+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBaseline",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.2216+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth"
     },
     {
         "Time": "2020-12-02T19:53:11.221608+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth",
         "Output": "=== RUN   TestExtractRestBasicAuth\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222169+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_only"
     },
     {
         "Time": "2020-12-02T19:53:11.222202+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_only",
         "Output": "=== RUN   TestExtractRestBasicAuth/username_only\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222218+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password"
     },
     {
         "Time": "2020-12-02T19:53:11.222226+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password",
         "Output": "=== RUN   TestExtractRestBasicAuth/username_and_password\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222243+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_file"
     },
     {
         "Time": "2020-12-02T19:53:11.222265+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_file",
         "Output": "=== RUN   TestExtractRestBasicAuth/username_and_password_file\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222273+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_and_password_file"
     },
     {
         "Time": "2020-12-02T19:53:11.222293+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_and_password_file",
         "Output": "=== RUN   TestExtractRestBasicAuth/username_and_password_and_password_file\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222321+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth",
         "Output": "--- PASS: TestExtractRestBasicAuth (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222345+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_only",
         "Output": "    --- PASS: TestExtractRestBasicAuth/username_only (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222357+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_only",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222362+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password",
         "Output": "    --- PASS: TestExtractRestBasicAuth/username_and_password (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222367+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222372+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_file",
         "Output": "    --- PASS: TestExtractRestBasicAuth/username_and_password_file (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222377+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_file",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222386+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_and_password_file",
         "Output": "    --- PASS: TestExtractRestBasicAuth/username_and_password_and_password_file (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222391+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth/username_and_password_and_password_file",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222397+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBasicAuth",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222421+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken"
     },
     {
         "Time": "2020-12-02T19:53:11.222425+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken",
         "Output": "=== RUN   TestExtractRestBearerToken\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22243+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_only"
     },
     {
         "Time": "2020-12-02T19:53:11.222435+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_only",
         "Output": "=== RUN   TestExtractRestBearerToken/bearer_token_only\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22244+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_file_only"
     },
     {
         "Time": "2020-12-02T19:53:11.222444+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_file_only",
         "Output": "=== RUN   TestExtractRestBearerToken/bearer_token_file_only\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222449+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both"
     },
     {
         "Time": "2020-12-02T19:53:11.222454+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both",
         "Output": "=== RUN   TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222462+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken",
         "Output": "--- PASS: TestExtractRestBearerToken (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222468+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_only",
         "Output": "    --- PASS: TestExtractRestBearerToken/bearer_token_only (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222483+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_only",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.22249+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_file_only",
         "Output": "    --- PASS: TestExtractRestBearerToken/bearer_token_file_only (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222498+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_file_only",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222506+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both",
         "Output": "    --- PASS: TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222518+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken/bearer_token_and_bearer_token_file_both",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222524+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestBearerToken",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222528+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders"
     },
     {
         "Time": "2020-12-02T19:53:11.222533+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders",
         "Output": "=== RUN   TestExtractRestHeaders\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222547+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders/github_content_type"
     },
     {
         "Time": "2020-12-02T19:53:11.222581+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders/github_content_type",
         "Output": "=== RUN   TestExtractRestHeaders/github_content_type\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222612+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders",
         "Output": "--- PASS: TestExtractRestHeaders (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222634+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders/github_content_type",
         "Output": "    --- PASS: TestExtractRestHeaders/github_content_type (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222639+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders/github_content_type",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222644+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestHeaders",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222668+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams"
     },
     {
         "Time": "2020-12-02T19:53:11.222694+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams",
         "Output": "=== RUN   TestExtractRestParams\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222728+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/no_url_query_string"
     },
     {
         "Time": "2020-12-02T19:53:11.222737+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/no_url_query_string",
         "Output": "=== RUN   TestExtractRestParams/no_url_query_string\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222743+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/set_per_page=2_in_URL_query_string"
     },
     {
         "Time": "2020-12-02T19:53:11.22278+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/set_per_page=2_in_URL_query_string",
         "Output": "=== RUN   TestExtractRestParams/set_per_page=2_in_URL_query_string\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222791+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams",
         "Output": "--- PASS: TestExtractRestParams (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.22281+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/no_url_query_string",
         "Output": "    --- PASS: TestExtractRestParams/no_url_query_string (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222817+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/no_url_query_string",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222822+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/set_per_page=2_in_URL_query_string",
         "Output": "    --- PASS: TestExtractRestParams/set_per_page=2_in_URL_query_string (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222827+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams/set_per_page=2_in_URL_query_string",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222831+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestExtractRestParams",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222836+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue"
     },
     {
         "Time": "2020-12-02T19:53:11.222841+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue",
         "Output": "=== RUN   TestValue\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222846+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue/basic_Value"
     },
     {
         "Time": "2020-12-02T19:53:11.222853+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue/basic_Value",
         "Output": "=== RUN   TestValue/basic_Value\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222858+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue",
         "Output": "--- PASS: TestValue (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222866+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue/basic_Value",
         "Output": "    --- PASS: TestValue/basic_Value (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222873+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue/basic_Value",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222879+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Test": "TestValue",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.222884+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222888+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/api/v1",
-        "Output": "ok  \tgithub.com/verifa/bubbly/api/v1\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/api/v1",
+        "Output": "ok  \tgithub.com/valocode/bubbly/api/v1\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.222895+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/api/v1",
+        "Package": "github.com/valocode/bubbly/api/v1",
         "Elapsed": 0.002
     },
     {
         "Time": "2020-12-02T19:53:11.273875+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion"
     },
     {
         "Time": "2020-12-02T19:53:11.273904+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion",
         "Output": "=== RUN   TestExtractJSONConversion\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273913+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion",
         "Output": "=== PAUSE TestExtractJSONConversion\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273918+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion"
     },
     {
         "Time": "2020-12-02T19:53:11.273923+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser"
     },
     {
         "Time": "2020-12-02T19:53:11.273928+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser",
         "Output": "=== RUN   TestApplyFromJSONParser\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273933+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser",
         "Output": "=== PAUSE TestApplyFromJSONParser\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273938+02:00",
         "Action": "pause",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser"
     },
     {
         "Time": "2020-12-02T19:53:11.273942+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestParser"
     },
     {
         "Time": "2020-12-02T19:53:11.273947+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestParser",
         "Output": "=== RUN   TestParser\n"
     },
     {
         "Time": "2020-12-02T19:53:11.27397+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestParser",
         "Output": "--- PASS: TestParser (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273976+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestParser",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.273983+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope"
     },
     {
         "Time": "2020-12-02T19:53:11.27399+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope",
         "Output": "=== RUN   TestScope\n"
     },
     {
         "Time": "2020-12-02T19:53:11.273995+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope/Basic_HCL_example_with_optionals"
     },
     {
         "Time": "2020-12-02T19:53:11.273999+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope/Basic_HCL_example_with_optionals",
         "Output": "=== RUN   TestScope/Basic_HCL_example_with_optionals\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274007+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope",
         "Output": "--- PASS: TestScope (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274013+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope/Basic_HCL_example_with_optionals",
         "Output": "    --- PASS: TestScope/Basic_HCL_example_with_optionals (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274022+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope/Basic_HCL_example_with_optionals",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274027+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestScope",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274032+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertBasic"
     },
     {
         "Time": "2020-12-02T19:53:11.274036+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertBasic",
         "Output": "=== RUN   TestInsertBasic\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274045+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertBasic",
         "Output": "--- PASS: TestInsertBasic (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274051+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertBasic",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274057+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertNested"
     },
     {
         "Time": "2020-12-02T19:53:11.274063+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertNested",
         "Output": "=== RUN   TestInsertNested\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274068+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertNested",
         "Output": "--- PASS: TestInsertNested (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274074+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestInsertNested",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274079+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion"
     },
     {
         "Time": "2020-12-02T19:53:11.274087+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion",
         "Output": "=== CONT  TestExtractJSONConversion\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274094+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.274099+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Output": "=== RUN   TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274106+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser"
     },
     {
         "Time": "2020-12-02T19:53:11.274111+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser",
         "Output": "=== CONT  TestApplyFromJSONParser\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274125+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline"
     },
     {
         "Time": "2020-12-02T19:53:11.27413+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "=== RUN   TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274134+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.274139+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Output": "=== CONT  TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274145+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Output": "    parser_json_test.go:69: Converting resource v1.default.extract.junit-extract to JSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.27415+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Output": "    parser_json_test.go:74: Resource v1.default.extract.junit-extract JSON representation: {\"resource\":{\"extract\":{\"junit-extract\":{\"api_version\":\"v1\",\"spec\":{\"input\":{\"file\":{}},\"source\":{\"file\":\"${self.input.file}\",\"format\":\"object({testsuites=object({duration=number,testsuite=list(object({failures=number,name=string,package=string,testcase=list(object({classname=string,name=string,time=number})),tests=number,time=number}))})})\"},\"type\":\"xml\"}}}}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274159+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline"
     },
     {
         "Time": "2020-12-02T19:53:11.274164+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "=== CONT  TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.27417+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    parser_json_test.go:230: Converting resource v1.default.load.junit-simple to JSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274175+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.27418+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Output": "=== RUN   TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274185+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline"
     },
     {
         "Time": "2020-12-02T19:53:11.274189+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "=== CONT  TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274194+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    parser_json_test.go:230: Converting resource v1.default.extract.junit-simple to JSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274199+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    parser_json_test.go:230: Converting resource v1.default.transform.junit-simple to JSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274211+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract"
     },
     {
         "Time": "2020-12-02T19:53:11.274217+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Output": "=== CONT  TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274221+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Output": "    parser_json_test.go:69: Converting resource v1.default.extract.sonarqube-extract to JSON\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274228+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Output": "    parser_json_test.go:74: Resource v1.default.extract.sonarqube-extract JSON representation: {\"resource\":{\"extract\":{\"sonarqube-extract\":{\"api_version\":\"v1\",\"spec\":{\"input\":{\"file\":{}},\"source\":{\"file\":\"${self.input.file}\",\"format\":\"object({issues=list(object({engineId=string,primaryLocation=object({filePath=string,message=string,textRange=object({endColumn=number,endLine=number,startColumn=number,startLine=number})}),ruleId=string,severity=string,type=string}))})\"},\"type\":\"json\"}}}}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274237+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion",
         "Output": "--- PASS: TestExtractJSONConversion (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274244+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Output": "    --- PASS: TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274249+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_junit_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274254+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Output": "    --- PASS: TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274259+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274264+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestExtractJSONConversion",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274268+02:00",
         "Action": "cont",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline"
     },
     {
         "Time": "2020-12-02T19:53:11.274273+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "=== CONT  TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274278+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    parser_json_test.go:188: Resource v1.default.extract.junit-simple ResourceOutput: {ty:{typeImpl:{typeImplSigil:{} AttrTypes:map[id:{typeImpl:{typeImplSigil:{} Kind:83}} status:{typeImpl:{typeImplSigil:{} Kind:83}} value:{typeImpl:{typeImplSigil:{} AttrTypes:map[testsuites:{typeImpl:{typeImplSigil:{} AttrTypes:map[duration:{typeImpl:{typeImplSigil:{} Kind:78}} testsuite:{typeImpl:{typeImplSigil:{} ElementTypeT:{typeImpl:{typeImplSigil:{} AttrTypes:map[failures:{typeImpl:{typeImplSigil:{} Kind:78}} name:{typeImpl:{typeImplSigil:{} Kind:83}} package:{typeImpl:{typeImplSigil:{} Kind:83}} testcase:{typeImpl:{typeImplSigil:{} ElementTypeT:{typeImpl:{typeImplSigil:{} AttrTypes:map[classname:{typeImpl:{typeImplSigil:{} Kind:83}} name:{typeImpl:{typeImplSigil:{} Kind:83}} time:{typeImpl:{typeImplSigil:{} Kind:78}}] AttrOptional:map[]}}}} tests:{typeImpl:{typeImplSigil:{} Kind:78}} time:{typeImpl:{typeImplSigil:{} Kind:78}}] AttrOptional:map[]}}}}] AttrOptional:map[]}}] AttrOptional:map[]}}] AttrOptional:map[]}} v:"
     },
     {
         "Time": "2020-12-02T19:53:11.274293+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "map[id: status:Success value:map[testsuites:map[duration:0xc0004d6ed0 testsuite:[map[failures:0xc0004d7200 name:Untitled suite in /Users/niko/Sites/casperjs/tests/suites/casper/agent.js package:tests/suites/casper/agent testcase:[map[classname:tests/suites/casper/agent name:Default user agent matches /CasperJS/ time:0xc0004d6f60] map[classname:tests/suites/casper/agent name:Default user agent matches /plop/ time:0xc0004d7020] map[classname:tests/suites/casper/agent name:Default user agent matches /plop/ time:0xc0004d70e0]] tests:0xc0004d71a0 time:0xc0004d71d0] map[failures:0xc0004d74a0 name:Untitled suite in /Users/niko/Sites/casperjs/tests/suites/casper/auth.js package:tests/suites/casper/auth testcase:[map[classname:tests/suites/casper/auth name:Subject equals the expected value time:0xc0004d72f0] map[classname:tests/suites/casper/auth name:Subject equals the expected value time:0xc0004d73b0]] tests:0xc0004d7440 time:0xc0004d7470]]]]]}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274301+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    parser_json_test.go:200: Resource v1.default.transform.junit-simple ResourceOutput: {ty:{typeImpl:{typeImplSigil:{} AttrTypes:map[id:{typeImpl:{typeImplSigil:{} Kind:83}} status:{typeImpl:{typeImplSigil:{} Kind:83}} value:{typeImpl:{typeImplSigil:{} Kind:83}}] AttrOptional:map[]}} v:map[id: status:Success value:[{\"table\":\"test_table\",\"fields\":[{\"name\":\"test_field\",\"Value\":\"This field exists in table_WALALALALA\"}],\"data\":null}]]}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274307+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser",
         "Output": "--- PASS: TestApplyFromJSONParser (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274312+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Output": "    --- PASS: TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274317+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274321+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Test": "TestApplyFromJSONParser",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.274326+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274332+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/parser",
-        "Output": "ok  \tgithub.com/verifa/bubbly/parser\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/parser",
+        "Output": "ok  \tgithub.com/valocode/bubbly/parser\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.274348+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/parser",
+        "Package": "github.com/valocode/bubbly/parser",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.374274+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly",
-        "Output": "?   \tgithub.com/verifa/bubbly\t[no test files]\n"
+        "Package": "github.com/valocode/bubbly",
+        "Output": "?   \tgithub.com/valocode/bubbly\t[no test files]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.375407+02:00",
         "Action": "skip",
-        "Package": "github.com/verifa/bubbly",
+        "Package": "github.com/valocode/bubbly",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.428998+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename"
     },
     {
         "Time": "2020-12-02T19:53:11.429033+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "=== RUN   TestCmdApplyFilename\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429044+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/local-sq-json\",\"host\":\"\",\"port\":\"\",\"token\":\"\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.42907+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m apply arguments \u001b[36marguments=\u001b[0m[]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429077+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"8080\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429103+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "Error: failed to apply configuration: Failed to create parser: Failed to get bubbly files: Cannot read from filename \"../parser/testdata/local-sq-json\"\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429129+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Output": "--- PASS: TestCmdApplyFilename (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429149+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyFilename",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429156+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup"
     },
     {
         "Time": "2020-12-02T19:53:11.4292+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup",
         "Output": "=== RUN   TestCmdApplyWithServerConfigsSetup\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429231+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured"
     },
     {
         "Time": "2020-12-02T19:53:11.429249+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "=== RUN   TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429282+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[1m\u001b[31mERR\u001b[0m\u001b[0m Error setting up DB: failed to create store: invalid provider: \n"
     },
     {
         "Time": "2020-12-02T19:53:11.429302+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429311+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429329+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.42937+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429389+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429418+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.42943+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429436+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429461+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429466+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429485+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429515+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429523+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"8070\",\"token\":\"\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429538+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m apply arguments \u001b[36marguments=\u001b[0m[]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429544+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"8070\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.42956+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "Apply result: true\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429573+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup",
         "Output": "--- PASS: TestCmdApplyWithServerConfigsSetup (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429586+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Output": "    --- PASS: TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429611+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup/basic_resource_apply_with_server_configs_pre-configured",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429617+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestCmdApplyWithServerConfigsSetup",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429624+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType"
     },
     {
         "Time": "2020-12-02T19:53:11.429631+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType",
         "Output": "=== RUN   TestDescribeValidResourceType\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429639+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe"
     },
     {
         "Time": "2020-12-02T19:53:11.429646+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "=== RUN   TestDescribeValidResourceType/basic_valid_resource_describe\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429651+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"8070\",\"token\":\"\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429657+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m describe arguments \u001b[36marguments=\u001b[0m[\"extract\",\"example_extract\"]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429662+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"8070\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429667+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[32mINF\u001b[0m custom bubbly host set \u001b[36murl=\u001b[0mhttp://localhost:8070\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429672+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m attempting to describe resource via GET request \u001b[36mroute=\u001b[0mhttp://localhost:8070/describe/extract/v1/example_extract\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429678+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType",
         "Output": "--- PASS: TestDescribeValidResourceType (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429683+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Output": "    --- PASS: TestDescribeValidResourceType/basic_valid_resource_describe (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429689+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType/basic_valid_resource_describe",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429698+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeValidResourceType",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429705+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType"
     },
     {
         "Time": "2020-12-02T19:53:11.429722+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType",
         "Output": "=== RUN   TestDescribeInvalidResourceType\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429731+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe"
     },
     {
         "Time": "2020-12-02T19:53:11.429739+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Output": "=== RUN   TestDescribeInvalidResourceType/basic_invalid_resource_describe\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429753+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"8070\",\"token\":\"\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429765+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m describe arguments \u001b[36marguments=\u001b[0m[\"destroyer\",\"example_destroyer\"]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429779+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"8070\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429803+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType",
         "Output": "--- PASS: TestDescribeInvalidResourceType (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429829+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Output": "    --- PASS: TestDescribeInvalidResourceType/basic_invalid_resource_describe (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429841+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType/basic_invalid_resource_describe",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429861+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeInvalidResourceType",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429883+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeHelpMessage"
     },
     {
         "Time": "2020-12-02T19:53:11.429908+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeHelpMessage",
         "Output": "=== RUN   TestDescribeHelpMessage\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429934+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeHelpMessage",
         "Output": "--- PASS: TestDescribeHelpMessage (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.429954+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeHelpMessage",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.429969+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeCmdSetup"
     },
     {
         "Time": "2020-12-02T19:53:11.42998+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeCmdSetup",
         "Output": "=== RUN   TestDescribeCmdSetup\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430003+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeCmdSetup",
         "Output": "--- PASS: TestDescribeCmdSetup (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.43001+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeCmdSetup",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430016+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg"
     },
     {
         "Time": "2020-12-02T19:53:11.430032+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg",
         "Output": "=== RUN   TestDescribeWithVersionArg\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430039+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument"
     },
     {
         "Time": "2020-12-02T19:53:11.430044+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "=== RUN   TestDescribeWithVersionArg/basic_resource_describe_with_port_argument\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430049+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"8070\",\"token\":\"\",\"version\":\"994icidj\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430059+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m describe arguments \u001b[36marguments=\u001b[0m[\"destroyer\",\"example_destroyer\"]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.43008+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"8070\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430086+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "Error: Invalid resource type destroyer. Use 'bubbly api-resources' for a complete list of supported resources.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430091+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg",
         "Output": "--- PASS: TestDescribeWithVersionArg (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.4301+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Output": "    --- PASS: TestDescribeWithVersionArg/basic_resource_describe_with_port_argument (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430105+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg/basic_resource_describe_with_port_argument",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.43011+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithVersionArg",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430114+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup"
     },
     {
         "Time": "2020-12-02T19:53:11.430118+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup",
         "Output": "=== RUN   TestDescribeWithServerConfigsSetup\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430123+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured"
     },
     {
         "Time": "2020-12-02T19:53:11.43013+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "=== RUN   TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430135+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":false,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"5050\",\"token\":\"\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430148+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m describe arguments \u001b[36marguments=\u001b[0m[\"destroyer\",\"example_destroyer\"]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430154+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":false,\"Host\":\"localhost\",\"Port\":\"5050\",\"Protocol\":\"http\",\"Token\":\"\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.43016+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "Error: Invalid resource type destroyer. Use 'bubbly api-resources' for a complete list of supported resources.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430164+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true"
     },
     {
         "Time": "2020-12-02T19:53:11.430169+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "=== RUN   TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430174+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m bubbly configuration \u001b[36mconfiguration=\u001b[0m{\"auth\":true,\"config\":\"\",\"filename\":\"../parser/testdata/sonarqube\",\"host\":\"localhost\",\"port\":\"5050\",\"token\":\"example_token\",\"version\":\"v1\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430181+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m describe arguments \u001b[36marguments=\u001b[0m[\"destroyer\",\"example_destroyer\"]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430186+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "\u001b[90m4:20PM\u001b[0m \u001b[33mDBG\u001b[0m merged bubbly configuration \u001b[36mconfiguration_merged=\u001b[0m{\"ServerConfig\":{\"Auth\":true,\"Host\":\"localhost\",\"Port\":\"5050\",\"Protocol\":\"http\",\"Token\":\"example_token\"}}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430191+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "Error: Invalid resource type destroyer. Use 'bubbly api-resources' for a complete list of supported resources.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430196+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup",
         "Output": "--- PASS: TestDescribeWithServerConfigsSetup (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430201+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Output": "    --- PASS: TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430214+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430219+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Output": "    --- PASS: TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430226+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup/basic_resource_describe_with_server_configs_pre-configured,_auth_true",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.43023+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestDescribeWithServerConfigsSetup",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430234+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg"
     },
     {
         "Time": "2020-12-02T19:53:11.430244+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg",
         "Output": "=== RUN   TestRootWithPortArg\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430249+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg/test_root"
     },
     {
         "Time": "2020-12-02T19:53:11.430254+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg/test_root",
         "Output": "=== RUN   TestRootWithPortArg/test_root\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430259+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg",
         "Output": "--- PASS: TestRootWithPortArg (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430264+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg/test_root",
         "Output": "    --- PASS: TestRootWithPortArg/test_root (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430268+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg/test_root",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430279+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithPortArg",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430283+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg"
     },
     {
         "Time": "2020-12-02T19:53:11.430287+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg",
         "Output": "=== RUN   TestRootWithInvalidArg\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430293+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg/test_root"
     },
     {
         "Time": "2020-12-02T19:53:11.430298+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg/test_root",
         "Output": "=== RUN   TestRootWithInvalidArg/test_root\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430303+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg/test_root",
         "Output": "Error: unknown flag: --invalid-arg\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430307+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg",
         "Output": "--- PASS: TestRootWithInvalidArg (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430312+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg/test_root",
         "Output": "    --- PASS: TestRootWithInvalidArg/test_root (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430317+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg/test_root",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430321+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Test": "TestRootWithInvalidArg",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.430326+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.43033+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/cmd",
-        "Output": "ok  \tgithub.com/verifa/bubbly/cmd\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/cmd",
+        "Output": "ok  \tgithub.com/valocode/bubbly/cmd\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.43035+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/cmd",
+        "Package": "github.com/valocode/bubbly/cmd",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.430714+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/events",
-        "Output": "?   \tgithub.com/verifa/bubbly/events\t[no test files]\n"
+        "Package": "github.com/valocode/bubbly/events",
+        "Output": "?   \tgithub.com/valocode/bubbly/events\t[no test files]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.430726+02:00",
         "Action": "skip",
-        "Package": "github.com/verifa/bubbly/events",
+        "Package": "github.com/valocode/bubbly/events",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.443811+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource"
     },
     {
         "Time": "2020-12-02T19:53:11.443852+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "=== RUN   TestPostResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443862+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "{\"level\":\"error\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Error setting up DB: failed to create store: invalid provider: \"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44387+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443894+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.4439+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443905+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443912+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443919+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443925+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443929+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443934+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443939+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443943+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443948+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.443952+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "{\"level\":\"info\",\"status\":200,\"method\":\"POST\",\"path\":\"/api/resource\",\"ip\":\"\",\"latency\":0.280664,\"user-agent\":\"\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444022+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Output": "--- PASS: TestPostResource (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444034+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestPostResource",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.444045+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource"
     },
     {
         "Time": "2020-12-02T19:53:11.44405+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "=== RUN   TestGetResource\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444055+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "{\"level\":\"error\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Error setting up DB: failed to create store: invalid provider: \"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444061+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444065+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44407+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444075+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444079+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444084+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444088+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444093+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444097+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444102+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444106+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444111+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444116+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "{\"level\":\"info\",\"status\":200,\"method\":\"POST\",\"path\":\"/api/resource\",\"ip\":\"\",\"latency\":0.147917,\"user-agent\":\"\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444133+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "{\"level\":\"error\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Error setting up DB: failed to create store: invalid provider: \"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444139+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444143+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444148+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444152+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444157+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444162+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444167+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444171+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44418+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444185+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444191+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444196+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444201+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "{\"level\":\"info\",\"status\":200,\"method\":\"GET\",\"path\":\"/api/resource/default/transform/junit\",\"ip\":\"\",\"latency\":0.060411,\"user-agent\":\"Gofight-client/1.0\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444212+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Output": "--- PASS: TestGetResource (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444217+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestGetResource",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.444222+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth"
     },
     {
         "Time": "2020-12-02T19:53:11.444226+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "=== RUN   TestHealth\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444239+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "{\"level\":\"error\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Error setting up DB: failed to create store: invalid provider: \"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444244+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444249+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444256+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444261+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444265+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44427+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444274+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444279+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444311+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444319+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444324+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444328+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444333+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "{\"level\":\"info\",\"status\":200,\"method\":\"GET\",\"path\":\"/healthz\",\"ip\":\"\",\"latency\":0.008311,\"user-agent\":\"\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44434+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Output": "--- PASS: TestHealth (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444345+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestHealth",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.444367+02:00",
         "Action": "run",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing"
     },
     {
         "Time": "2020-12-02T19:53:11.444371+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "=== RUN   TestUploadFailing\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444376+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "{\"level\":\"error\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Error setting up DB: failed to create store: invalid provider: \"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444394+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444399+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": " - using env:\texport GIN_MODE=release\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444403+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": " - using code:\tgin.SetMode(gin.ReleaseMode)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444427+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444431+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/verifa/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /healthz                  --\u003e github.com/valocode/bubbly/server.InitializeRoutes.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444436+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/verifa/bubbly/server.PostResource (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/resource             --\u003e github.com/valocode/bubbly/server.PostResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444457+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/verifa/bubbly/server.GetResource (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /api/resource/:namespace/:kind/:name --\u003e github.com/valocode/bubbly/server.GetResource (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444461+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/verifa/bubbly/server.Query (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /api/graphql              --\u003e github.com/valocode/bubbly/server.Query (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44447+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/verifa/bubbly/server.status (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/status                --\u003e github.com/valocode/bubbly/server.status (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444475+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/verifa/bubbly/server.versionHandler (4 handlers)\n"
+        "Output": "[GIN-debug] GET    /v1/version               --\u003e github.com/valocode/bubbly/server.versionHandler (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444479+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
-        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/verifa/bubbly/server.upload (4 handlers)\n"
+        "Output": "[GIN-debug] POST   /alpha1/upload            --\u003e github.com/valocode/bubbly/server.upload (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444484+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "[GIN-debug] GET    /swagger/*any             --\u003e github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (4 handlers)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444488+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "{\"level\":\"warn\",\"status\":400,\"method\":\"POST\",\"path\":\"/alpha1/upload\",\"ip\":\"\",\"latency\":0.054079,\"user-agent\":\"Gofight-client/1.0\",\"time\":\"2020-12-02T16:20:22+02:00\",\"message\":\"Request\"}\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444494+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Output": "--- PASS: TestUploadFailing (0.00s)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444498+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Test": "TestUploadFailing",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.444503+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Output": "PASS\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444507+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/server",
-        "Output": "ok  \tgithub.com/verifa/bubbly/server\t(cached)\n"
+        "Package": "github.com/valocode/bubbly/server",
+        "Output": "ok  \tgithub.com/valocode/bubbly/server\t(cached)\n"
     },
     {
         "Time": "2020-12-02T19:53:11.44452+02:00",
         "Action": "pass",
-        "Package": "github.com/verifa/bubbly/server",
+        "Package": "github.com/valocode/bubbly/server",
         "Elapsed": 0.001
     },
     {
         "Time": "2020-12-02T19:53:11.444884+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/store",
-        "Output": "?   \tgithub.com/verifa/bubbly/store\t[no test files]\n"
+        "Package": "github.com/valocode/bubbly/store",
+        "Output": "?   \tgithub.com/valocode/bubbly/store\t[no test files]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.444914+02:00",
         "Action": "skip",
-        "Package": "github.com/verifa/bubbly/store",
+        "Package": "github.com/valocode/bubbly/store",
         "Elapsed": 0
     },
     {
         "Time": "2020-12-02T19:53:11.46483+02:00",
         "Action": "output",
-        "Package": "github.com/verifa/bubbly/storefront",
-        "Output": "?   \tgithub.com/verifa/bubbly/storefront\t[no test files]\n"
+        "Package": "github.com/valocode/bubbly/storefront",
+        "Output": "?   \tgithub.com/valocode/bubbly/storefront\t[no test files]\n"
     },
     {
         "Time": "2020-12-02T19:53:11.464854+02:00",
         "Action": "skip",
-        "Package": "github.com/verifa/bubbly/storefront",
+        "Package": "github.com/valocode/bubbly/storefront",
         "Elapsed": 0
     }
 ]

--- a/integration/testdata/testautomation/golang/unit-report.xml
+++ b/integration/testdata/testautomation/golang/unit-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="55" failures="0" time="0.350" name="github.com/verifa/bubbly/api">
+	<testsuite tests="55" failures="0" time="0.350" name="github.com/valocode/bubbly/api">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -60,7 +60,7 @@
 		<testcase classname="api" name="TestNewResourceFails/basic_unsupported_resource_creation" time="0.000"></testcase>
 		<testcase classname="api" name="TestNewResourcesFromBlocks/basic_all_resource_types" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="110" failures="0" time="0.211" name="github.com/verifa/bubbly/api/core">
+	<testsuite tests="110" failures="0" time="0.211" name="github.com/valocode/bubbly/api/core">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -175,7 +175,7 @@
 		<testcase classname="core" name="TestResourceBlockLabels/basic_extract_without_metadata" time="0.000"></testcase>
 		<testcase classname="core" name="TestResourceBlockString/basic_extract_without_metadata" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="120" failures="0" time="0.232" name="github.com/verifa/bubbly/api/v1">
+	<testsuite tests="120" failures="0" time="0.232" name="github.com/valocode/bubbly/api/v1">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -300,7 +300,7 @@
 		<testcase classname="v1" name="TestValue" time="0.000"></testcase>
 		<testcase classname="v1" name="TestValue/basic_Value" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="10" failures="0" time="0.279" name="github.com/verifa/bubbly/bubbly">
+	<testsuite tests="10" failures="0" time="0.279" name="github.com/valocode/bubbly/bubbly">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -315,7 +315,7 @@
 		<testcase classname="bubbly" name="TestApply" time="0.000"></testcase>
 		<testcase classname="bubbly" name="TestApply/sonarqube" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="20" failures="0" time="0.231" name="github.com/verifa/bubbly/client">
+	<testsuite tests="20" failures="0" time="0.231" name="github.com/valocode/bubbly/client">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -340,7 +340,7 @@
 		<testcase classname="client" name="TestDescribeResourceGroup" time="0.000"></testcase>
 		<testcase classname="client" name="TestDescribeResourceGroup/basic_extract_resource_group_describe" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="90" failures="0" time="0.454" name="github.com/verifa/bubbly/cmd">
+	<testsuite tests="90" failures="0" time="0.454" name="github.com/valocode/bubbly/cmd">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -435,7 +435,7 @@
 		<testcase classname="cmd" name="TestRootWithInvalidArg" time="0.000"></testcase>
 		<testcase classname="cmd" name="TestRootWithInvalidArg/test_root" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="35" failures="0" time="0.202" name="github.com/verifa/bubbly/cmd/util">
+	<testsuite tests="35" failures="0" time="0.202" name="github.com/valocode/bubbly/cmd/util">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -485,7 +485,7 @@
 		<testcase classname="util" name="TestUsageErrorf" time="0.000"></testcase>
 		<testcase classname="util" name="TestUsageErrorf/basic" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="50" failures="0" time="0.190" name="github.com/verifa/bubbly/config">
+	<testsuite tests="50" failures="0" time="0.190" name="github.com/valocode/bubbly/config">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -540,7 +540,7 @@
 		<testcase classname="config" name="TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults" time="0.000"></testcase>
 		<testcase classname="config" name="TestSetupConfigs/basic_creation_of_Config_from_viper_bindings_and_defaults#01" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="50" failures="0" time="0.242" name="github.com/verifa/bubbly/parser">
+	<testsuite tests="50" failures="0" time="0.242" name="github.com/valocode/bubbly/parser">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -595,7 +595,7 @@
 		<testcase classname="parser" name="TestApplyFromJSONParser/basic_apply_from_json_over_junit_pipeline" time="0.000"></testcase>
 		<testcase classname="parser" name="TestExtractJSONConversion/basic_JSON_conversion_for_sonarqube_extract" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="20" failures="0" time="0.407" name="github.com/verifa/bubbly/server">
+	<testsuite tests="20" failures="0" time="0.407" name="github.com/valocode/bubbly/server">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>
@@ -620,7 +620,7 @@
 		<testcase classname="server" name="TestHealth" time="0.000"></testcase>
 		<testcase classname="server" name="TestUploadFailing" time="0.000"></testcase>
 	</testsuite>
-	<testsuite tests="35" failures="0" time="0.190" name="github.com/verifa/bubbly/util/normalise">
+	<testsuite tests="35" failures="0" time="0.190" name="github.com/valocode/bubbly/util/normalise">
 		<properties>
 			<property name="go.version" value="go1.15.5"></property>
 		</properties>

--- a/interval/channels.go
+++ b/interval/channels.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 )
 
 type Channels map[string]chan RunAction

--- a/interval/worker.go
+++ b/interval/worker.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hako/durafmt"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api"
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	v1 "github.com/verifa/bubbly/api/v1"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	v1 "github.com/valocode/bubbly/api/v1"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 )
 
 const (

--- a/interval/worker_test.go
+++ b/interval/worker_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/verifa/bubbly/api"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 )
 
 // parseBubblyFile parses a .bubbly file and returns a slice of core.Resource

--- a/main.go
+++ b/main.go
@@ -3,22 +3,22 @@ package main
 import (
 	"os"
 
-	"github.com/verifa/bubbly/docs"
-	_ "github.com/verifa/bubbly/docs"
+	"github.com/valocode/bubbly/docs"
+	_ "github.com/valocode/bubbly/docs"
 
 	"github.com/imdario/mergo"
 
 	"github.com/rs/zerolog"
-	"github.com/verifa/bubbly/cmd"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/cmd"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 // @title Bubbly
 // @version 0.1.1
 // @description this is the bubbly API server
 // @contact.name API Support
-// @contact.url https://github.com/verifa/bubbly/issues
+// @contact.url https://github.com/valocode/bubbly/issues
 // @contact.email info@bubbly.dev
 
 // @license.name Mozilla Public License Version 2.0

--- a/parser/decode.go
+++ b/parser/decode.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/dynblock"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/parser/decode_test.go
+++ b/parser/decode_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/parser/variables.go
+++ b/parser/variables.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/dynblock"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/server/graphql.go
+++ b/server/graphql.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
 )
 
 type queryReq struct {

--- a/server/graphql_test.go
+++ b/server/graphql_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/appleboy/gofight"
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/env"
-	testData "github.com/verifa/bubbly/server/testdata/upload"
+	"github.com/valocode/bubbly/env"
+	testData "github.com/valocode/bubbly/server/testdata/upload"
 )
 
 func IntegrationTestQuery(t *testing.T) {

--- a/server/resource.go
+++ b/server/resource.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
 )
 
 // PostResource godoc

--- a/server/routes.go
+++ b/server/routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	echoSwagger "github.com/swaggo/echo-swagger"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 // initializeRoutes Builds the endpoints and grouping for a gin router

--- a/server/schema.go
+++ b/server/schema.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
 )
 
 // PostSchema godoc

--- a/server/server.go
+++ b/server/server.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ziflex/lecho/v2"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 type Server struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 )
 
 func TestHealth(t *testing.T) {

--- a/server/testdata/upload/upload-failing.go
+++ b/server/testdata/upload/upload-failing.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"github.com/appleboy/gofight/v2"
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/server/testdata/upload/upload-passing.go
+++ b/server/testdata/upload/upload-passing.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/server/upload.go
+++ b/server/upload.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
 )
 
 // upload godoc

--- a/server/upload_test.go
+++ b/server/upload_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/appleboy/gofight/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/env"
-	testData "github.com/verifa/bubbly/server/testdata/upload"
+	"github.com/valocode/bubbly/env"
+	testData "github.com/valocode/bubbly/server/testdata/upload"
 )
 
 // This creates a passing test for the upload route

--- a/store/cockroachdb.go
+++ b/store/cockroachdb.go
@@ -8,8 +8,8 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // FIXME: because Roach provider was heavy dependent on Postgres,

--- a/store/datatree.go
+++ b/store/datatree.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/store/datatree_test.go
+++ b/store/datatree_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // some debugging function

--- a/store/graphql.go
+++ b/store/graphql.go
@@ -6,7 +6,7 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/store/migration.go
+++ b/store/migration.go
@@ -8,11 +8,11 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 
-	"github.com/verifa/bubbly/config"
+	"github.com/valocode/bubbly/config"
 
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/env"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -209,7 +209,7 @@ func alterColumnStatement(bCtx *env.BubblyContext, m *migration, info tableInfo,
 		break
 	case config.CockroachDBStore:
 		// FIXME
-		// https://github.com/verifa/bubbly/issues/201
+		// https://github.com/valocode/bubbly/issues/201
 		// cockroach doesn't support altering column types in a transaction, so this horrible workaround
 		// has to be used instead. This will completely remove data from the original column
 

--- a/store/migration_test.go
+++ b/store/migration_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 
 	"github.com/stretchr/testify/require"
 )

--- a/store/postgres.go
+++ b/store/postgres.go
@@ -12,9 +12,9 @@ import (
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/log/zerologadapter"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )

--- a/store/provider.go
+++ b/store/provider.go
@@ -2,8 +2,8 @@ package store
 
 import (
 	"github.com/graphql-go/graphql"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
 )
 
 // Provider provides an interface for persisting readiness data.

--- a/store/schema.go
+++ b/store/schema.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/store/schema_diff.go
+++ b/store/schema_diff.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 )
 
 // compareSchema will take 2 schemas as arguments and return a Changelog

--- a/store/schema_diff_test.go
+++ b/store/schema_diff_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 )
 
 func TestCompareSchema(t *testing.T) {

--- a/store/schemagraph.go
+++ b/store/schemagraph.go
@@ -3,7 +3,7 @@ package store
 import (
 	"fmt"
 
-	"github.com/verifa/bubbly/api/core"
+	"github.com/valocode/bubbly/api/core"
 )
 
 // schemaGraph creates a graph from the bubbly schema

--- a/store/schemagraph_test.go
+++ b/store/schemagraph_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	testData "github.com/verifa/bubbly/store/testdata"
+	testData "github.com/valocode/bubbly/store/testdata"
 )
 
 func printSchemaGraph(graph *schemaGraph) {

--- a/store/store.go
+++ b/store/store.go
@@ -9,9 +9,9 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 // New creates a new Store for the given config.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
-	testData "github.com/verifa/bubbly/store/testdata"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
+	testData "github.com/valocode/bubbly/store/testdata"
 )
 
 var queryTests = []struct {

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -5,9 +5,9 @@ import (
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/stretchr/testify/require"
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/parser"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/parser"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/store/triggers.go
+++ b/store/triggers.go
@@ -7,13 +7,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 
-	"github.com/verifa/bubbly/api"
-	"github.com/verifa/bubbly/api/common"
-	"github.com/verifa/bubbly/api/core"
-	v1 "github.com/verifa/bubbly/api/v1"
-	"github.com/verifa/bubbly/client"
-	"github.com/verifa/bubbly/env"
-	"github.com/verifa/bubbly/events"
+	"github.com/valocode/bubbly/api"
+	"github.com/valocode/bubbly/api/common"
+	"github.com/valocode/bubbly/api/core"
+	v1 "github.com/valocode/bubbly/api/v1"
+	"github.com/valocode/bubbly/client"
+	"github.com/valocode/bubbly/env"
+	"github.com/valocode/bubbly/events"
 )
 
 type Kind int

--- a/store/triggers_test.go
+++ b/store/triggers_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
-	"github.com/verifa/bubbly/api/core"
-	"github.com/verifa/bubbly/config"
-	"github.com/verifa/bubbly/env"
+	"github.com/valocode/bubbly/api/core"
+	"github.com/valocode/bubbly/config"
+	"github.com/valocode/bubbly/env"
 )
 
 // TestEventTrigger tests that saving a new resource to the store results in

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Verifa. Built with docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Valocode. Built with docusaurus.`,
     },
   },
   presets: [


### PR DESCRIPTION
The package names have been changed to `github.com/valocode`, as discussed in #11. Once this is in, I can upgrade to NATS v2.