### PR TITLE
Bug fixed in the GraphQL resolver

### DIFF
--- a/integration/testdata/schema/schema.bubbly
+++ b/integration/testdata/schema/schema.bubbly
@@ -18,6 +18,7 @@ table "repo" {
         unique = true
     }
     table "repo_version" {
+        // join "repo" {}
         field "commit" {
             type = string
             unique = true

--- a/store/schemagraph.go
+++ b/store/schemagraph.go
@@ -42,6 +42,12 @@ type schemaEdge struct {
 	rel  relType
 }
 
+// isScalar returns true if the return type from the node which this edge points
+// to should be scalar. This is true, unless the edge relationship is oneToMany
+func (e *schemaEdge) isScalar() bool {
+	return e.rel != oneToMany
+}
+
 // schemaPath is a list graph edges
 type schemaPath []*schemaEdge
 

--- a/store/schemagraph_test.go
+++ b/store/schemagraph_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,7 +26,7 @@ func printSchemaNode(node *schemaNode, depth int) {
 }
 
 func TestSchemaGraph(t *testing.T) {
-	tables := testData.Tables(t)
+	tables := testData.Tables(t, filepath.FromSlash("testdata/tables.hcl"))
 	graph, err := newSchemaGraph(tables)
 	require.NoErrorf(t, err, "failed to create schema graph")
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -248,7 +248,7 @@ var sqlGenTests = []struct {
 		data:   "data1.hcl",
 		query: `
 		{
-			B(whbbt: "va1") {
+			B(whbbt: "vb1") {
 				whbbt
 				A(whaat: "va1") {
 					whaat
@@ -260,10 +260,8 @@ var sqlGenTests = []struct {
 			"B": []interface{}{
 				map[string]interface{}{
 					"whbbt": "vb1",
-					"A": []interface{}{
-						map[string]interface{}{
-							"whaat": "va1",
-						},
+					"A": map[string]interface{}{
+						"whaat": "va1",
 					},
 				},
 			},

--- a/store/testdata/data.hcl
+++ b/store/testdata/data.hcl
@@ -21,6 +21,14 @@ data "child_a" {
     }
 }
 
+// Regression test: sibling child nodes
+data "child_c" {
+    joins = ["root"]
+    fields = {
+        "name": "sibling_child"
+    }
+}
+
 data "grandchild_a" {
     joins = ["child_a"]
     fields = {

--- a/store/testdata/sqlgen/data0.hcl
+++ b/store/testdata/sqlgen/data0.hcl
@@ -1,0 +1,14 @@
+#
+# Data for tables0.hcl
+#
+data "A" {
+	fields = {
+		"whaat": "va1"
+	}
+}
+
+data "B" {
+	fields = {
+		"whbbt": "vb1"
+	}
+}

--- a/store/testdata/sqlgen/data1.hcl
+++ b/store/testdata/sqlgen/data1.hcl
@@ -1,0 +1,15 @@
+#
+# Data for tables1.hcl
+#
+data "A" {
+	fields = {
+		"whaat": "va1"
+	}
+}
+
+data "B" {
+	joins = ["A"]
+	fields = {
+		"whbbt": "vb1"
+	}
+}

--- a/store/testdata/sqlgen/data2.hcl
+++ b/store/testdata/sqlgen/data2.hcl
@@ -1,0 +1,22 @@
+#
+# Data for tables2.hcl
+#
+data "A" {
+	fields = {
+		"whaat": "va1"
+	}
+}
+
+data "B" {
+	joins = ["A"]
+	fields = {
+		"whbbt": "vb1"
+	}
+}
+
+data "C" {
+	joins = ["A"]
+	fields = {
+		"whcct": "vc1"
+	}
+}

--- a/store/testdata/sqlgen/data3.hcl
+++ b/store/testdata/sqlgen/data3.hcl
@@ -1,0 +1,22 @@
+#
+# Data for tables3.hcl
+#
+data "A" {
+	fields = {
+		"whaat": "va1"
+	}
+}
+
+data "B" {
+	joins = ["A"]
+	fields = {
+		"whbbt": "vb1"
+	}
+}
+
+data "C" {
+	joins = ["B"]
+	fields = {
+		"whcct": "vc1"
+	}
+}

--- a/store/testdata/sqlgen/data4.hcl
+++ b/store/testdata/sqlgen/data4.hcl
@@ -1,0 +1,29 @@
+#
+# Data for tables4.hcl
+#
+data "A" {
+	fields = {
+		"whaat": "va1"
+	}
+}
+
+data "B" {
+	joins = ["A"]
+	fields = {
+		"whbbt": "vb1"
+	}
+}
+
+data "C" {
+	joins = ["B"]
+	fields = {
+		"whcct": "vc1"
+	}
+}
+
+data "D" {
+	joins = ["A"]
+	fields = {
+		"whddt": "vd1"
+	}
+}

--- a/store/testdata/sqlgen/tables0.hcl
+++ b/store/testdata/sqlgen/tables0.hcl
@@ -1,0 +1,15 @@
+#
+# Two unrelated tables:
+# 	The tables `A` and `B` are not related.
+#
+table "A" {
+	field "whaat" {
+		type = string
+	}
+}
+
+table "B" {
+	field "whbbt" {
+		type = string
+	}
+}

--- a/store/testdata/sqlgen/tables1.hcl
+++ b/store/testdata/sqlgen/tables1.hcl
@@ -1,0 +1,16 @@
+#
+# One-to-many relationship:
+# 	The table `A` is the parent table, and 
+# 	the table `B` is the related table.
+#
+table "A" {
+	field "whaat" {
+		type = string
+	}
+
+	table "B" {
+		field "whbbt" {
+			type = string
+		}
+	}
+}

--- a/store/testdata/sqlgen/tables2.hcl
+++ b/store/testdata/sqlgen/tables2.hcl
@@ -1,0 +1,23 @@
+#
+# Multiple one-to-many relationships as siblings:
+#   The table `A` is the parent table, and 
+#     the table `B` is the related table.
+#     the table `C` is another related table.
+#
+table "A" {
+	field "whaat" {
+		type = string
+	}
+
+	table "B" {
+		field "whbbt" {
+			type = string
+		}
+	}
+
+	table "C" {
+		field "whcct" {
+			type = string
+		}
+	}
+}

--- a/store/testdata/sqlgen/tables3.hcl
+++ b/store/testdata/sqlgen/tables3.hcl
@@ -1,0 +1,25 @@
+#
+# Multi-level nested one-to-many relationships:
+# 	The table `A` is the parent table to `B`, and 
+# 	the table `B` is the related table to `A`.
+#
+#   The table `B` is a parent table to `C`,
+#   and the table `C` is the related table to `B.
+#
+table "A" {
+	field "whaat" {
+		type = string
+	}
+
+	table "B" {
+		field "whbbt" {
+			type = string
+		}
+
+		table "C" {
+			field "whcct" {
+				type = string
+			}
+		}
+	}
+}

--- a/store/testdata/sqlgen/tables4.hcl
+++ b/store/testdata/sqlgen/tables4.hcl
@@ -1,0 +1,32 @@
+#
+# Multi-level nested and sibling one-to-many relationships:
+#   The table `A` is the parent table to `B` and `D`,
+#     the table `B` is the related table to `A`.
+#     the table `D` is the related table to `A`.
+#
+#   The table `B` is a parent table to `C`,
+#     the table `C` is the related table to `B.
+#
+table "A" {
+	field "whaat" {
+		type = string
+	}
+
+	table "B" {
+		field "whbbt" {
+			type = string
+		}
+
+		table "C" {
+			field "whcct" {
+				type = string
+			}
+		}
+	}
+
+	table "D" {
+		field "whddt" {
+			type = string
+		}
+	}
+}

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -11,27 +11,28 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func Tables(t *testing.T) core.Tables {
+func Tables(t *testing.T, fromFile string) core.Tables {
+	t.Helper()
 
-	// Parse tables
 	bCtx := env.NewBubblyContext()
 	tableWrapper := struct {
 		Tables core.Tables `hcl:"table,block"`
 	}{}
-	body, err := parser.MergedHCLBodies(bCtx, "testdata/tables.hcl")
+	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse tables")
 	err = parser.DecodeExpandBody(bCtx, body, &tableWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode tables")
 	return tableWrapper.Tables
 }
 
-func DataBlocks(t *testing.T) core.DataBlocks {
-	// Parse data blocks
+func DataBlocks(t *testing.T, fromFile string) core.DataBlocks {
+	t.Helper()
+
 	bCtx := env.NewBubblyContext()
 	dataWrapper := struct {
 		Data core.DataBlocks `hcl:"data,block"`
 	}{}
-	body, err := parser.MergedHCLBodies(bCtx, "testdata/data.hcl")
+	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse data blocks")
 	err = parser.DecodeExpandBody(bCtx, body, &dataWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode data blocks")

--- a/store/testdata/tables.hcl
+++ b/store/testdata/tables.hcl
@@ -47,6 +47,8 @@ table "test_run" {
     
 }
 
+// Original test for GraphQL resolver's ability 
+// to deal with many-to-many relationships.
 table "root" {
     field "name" {
         unique = true
@@ -68,6 +70,13 @@ table "root" {
     table "child_b" {
         // Table root has only one child_b (one-to-one)
         unique = true
+        field "name" {
+            unique = true
+            type = string
+        }
+    }
+    // Regression test: sibling child nodes
+    table "child_c" {
         field "name" {
             unique = true
             type = string


### PR DESCRIPTION
## Update

As discussed, this is useful enough to warrant inclusion into `main`. The siblings bug described below had been fixed by @jlarfors, and I have added extra tests for the GraphQL resolver. 

These things lay the foundation for moving forward with the upcoming enhancements to the resolver, as well as facilitate making progress with the pilots :shipit: 

## Original issue

I could use some help with this. There are two issues. I've made some changes to the code, but the issues were there to begin with, that is the `main` branch has them too, it's just we didn't test for these before.

The main change I made is to remove node hopping. We can't skip nodes because in a schema, where multiple routes exist between nodes, the path between two nodes is not uniquely defined.

I've also added a bunch of tests with smaller schema/data file in hopes to isolate the problems better and to set up the foundation for adding more test cases without having to clutter _THE_ one and only test schema. We'll need more test cases for the GraphQL arguments, so this is a good start.

You don't have to run the whole test suite to see the issues in action, one of `TestPostgres` or `TestMe`, or `TestPostgresSQLGen` in `store` module will do. `TestMe` is meant to be a temporary short(er) test for debug purposes.

## Inverse relationships

The GraphQL resolver fails to correctly resolve inverse relationships, such as the following.

```hcl
# The parent table
table "A" {

  # field whatever a

  # The related table
  table "B" {
     # field whatever b
  }
}
```

In this case, the following GraphQL query would work.

```graphql
A {
  # field whatever a

  B {
     # field whatever b
  }
}
```

But the inverse query won't.

```graphql
B {
   # field whatever b

  A {
    # field whatever A
  }
}
```

In this case, `B` will point to a `nil`. I believe the relationship should work both ways.

## Sibling fields.

Now consider the schema

```hcl
# The parent table
table "A" {

  # field whatever a

  # First related table
  table "B" {
    # field whatever b
  }

  # Second related table
  table "C" {
    # field whatever c
  }
}
```

With this, either of the following GraphQL queries would succeed

```graphql
A {
  # field whatever a
  B {
    # field whatever b
  }
}
```

```graphql
A {
  # field whatever a
  C {
    # field whatever c
  }
}
```

But the field with the sibling related tables would fail, the second table would return null

```graphql
A {
  # field whatever a
  B {
    # field whatever b
  }
  C {
    # field whatever c
  }
}
```

The odd thing about this is that the correct SQL is being generated, and the correct result is returned from the database, as far as I could tell. But somehow GraphQL module ignores the second sibling element.

Helb?! 🙀 
