### PR TITLE
Fix Echo's `Bind` behaviour to use the more precise `BindBody`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/terraform v0.14.3
 	github.com/imdario/mergo v0.3.11
 	github.com/jackc/pgx/v4 v4.10.1
-	github.com/labstack/echo/v4 v4.1.17
+	github.com/labstack/echo/v4 v4.2.1
 	github.com/lib/pq v1.9.0 // indirect
 	github.com/likexian/gokit v0.20.15
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/labstack/echo/v4 v4.0.0/go.mod h1:tZv7nai5buKSg5h/8E6zz4LsD/Dqh9/91Mvs7Z5Zyno=
 github.com/labstack/echo/v4 v4.1.17 h1:PQIBaRplyRy3OjwILGkPg89JRtH2x5bssi59G2EL3fo=
 github.com/labstack/echo/v4 v4.1.17/go.mod h1:Tn2yRQL/UclUalpb5rPdXDevbkJ+lp/2svdyFBg6CHQ=
+github.com/labstack/echo/v4 v4.2.1 h1:LF5Iq7t/jrtUuSutNuiEWtB5eiHfZ5gSe2pcu5exjQw=
+github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.2.8/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -932,6 +934,8 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 h1:Hir2P/De0WpUhtrKGGjvSb2YxUgyZ7EFOSLIcSSpiwE=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/server/graphql.go
+++ b/server/graphql.go
@@ -33,7 +33,9 @@ type apiResponse struct {
 // @Router /graphql [post]
 func (*Server) Query(bCtx *env.BubblyContext, c echo.Context) error {
 	var query queryReq
-	if err := c.Bind(&query); err != nil {
+
+	binder := &echo.DefaultBinder{}
+	if err := binder.BindBody(c, &query); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 

--- a/server/resource.go
+++ b/server/resource.go
@@ -31,7 +31,9 @@ func (a *Server) PostResource(bCtx *env.BubblyContext,
 	// read the resource into a ResourceBlockJSON which keeps the spec{} block
 	// as bytes
 	resJSON := core.ResourceBlockJSON{}
-	if err := c.Bind(&resJSON); err != nil {
+
+	binder := &echo.DefaultBinder{}
+	if err := binder.BindBody(c, &resJSON); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 

--- a/server/schema.go
+++ b/server/schema.go
@@ -22,7 +22,8 @@ import (
 // @Router /schema [post]
 func (a *Server) PostSchema(bCtx *env.BubblyContext, c echo.Context) error {
 	var schema core.Tables
-	if err := c.Bind(&schema); err != nil {
+	binder := &echo.DefaultBinder{}
+	if err := binder.BindBody(c, &schema); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 

--- a/server/upload.go
+++ b/server/upload.go
@@ -23,7 +23,9 @@ import (
 // @Router /upload [post]
 func (a *Server) upload(bCtx *env.BubblyContext, c echo.Context) error {
 	var data core.DataBlocks
-	if err := c.Bind(&data); err != nil {
+
+	binder := &echo.DefaultBinder{}
+	if err := binder.BindBody(c, &data); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 


### PR DESCRIPTION
Previous versions of echo had an issue in which the `Bind` behaviour would be used generically for path params, query params and then body (in that order). What this means is that if you attempt to use echo's `Context.Bind` with a context that has either path or query params, it will use those, error early and never bind the JSON body. See labstack/echo#1356 for description.

This becomes an issue for us with our SaaS product, which makes use of an auth middleware that introduces path params to routes that otherwise do not have them.

Luckily, this has been fixed in at least v4.2.1 via either struct tagging or `echo.DefaultBinder{}`'s `BindBody` method. This PR simply bumps our dependency and introduces this use instead of the old `Bind` :)

Signed-off-by: Ben Marsden <bmarsden10@gmail.com>