### PR TITLE
fix getresource error

### DIFF
--- a/agent/component/datastore/data_store.go
+++ b/agent/component/datastore/data_store.go
@@ -49,12 +49,6 @@ type DataStore struct {
 func (d *DataStore) defaultSubscriptions() component.DesiredSubscriptions {
 	return component.DesiredSubscriptions{
 		component.DesiredSubscription{
-			Subject: component.StoreGetResource,
-			Queue:   component.StoreQueue,
-			Handler: d.GetResourceHandler,
-			Encoder: nats.DEFAULT_ENCODER,
-		},
-		component.DesiredSubscription{
 			Subject: component.StorePostResource,
 			Queue:   component.StoreQueue,
 			Handler: d.PostResourceHandler,

--- a/agent/component/datastore/handler.go
+++ b/agent/component/datastore/handler.go
@@ -11,40 +11,6 @@ import (
 	"github.com/valocode/bubbly/env"
 )
 
-// GetResourceHandler is responsible for handling subscriptions on the
-// StoreGetResource Subject. It takes a *nats.
-// Msg containing the id of a resource and sends a Publication back
-// containing the []byte representation of the resource.
-func (d *DataStore) GetResourceHandler(bCtx *env.BubblyContext, m *nats.Msg) error {
-	bCtx.Logger.Debug().
-		Interface("subscription", m.Sub).
-		Str("component", string(d.Type)).
-		Msg("processing message")
-
-	result := d.Store.Query(string(m.Data))
-
-	if result.HasErrors() {
-		return fmt.Errorf("failed to process message: %v", result.Errors)
-	}
-
-	resultBytes, err := json.Marshal(result.Data)
-
-	if err != nil {
-		return fmt.Errorf("failed to marshal result of GetResource query: %w", err)
-	}
-
-	// We use the Publish method and a Publication to reply! You'll notice
-	// that despite using a separate message system (
-	// request/reply vs subscribe/publish) the behaviour does not change much.
-	d.Publish(bCtx, component.Publication{
-		Subject: component.Subject(m.Reply),
-		Data:    resultBytes,
-		Encoder: nats.DEFAULT_ENCODER,
-	})
-
-	return nil
-}
-
 // PostResourceHandler receives a core.Data representation of the data and attempts
 // to load it into the store. Publishes a reply containing a nil error on failure
 func (d *DataStore) PostResourceHandler(bCtx *env.BubblyContext, m *nats.Msg) error {

--- a/agent/component/datastore/handler.go
+++ b/agent/component/datastore/handler.go
@@ -154,6 +154,10 @@ func (d *DataStore) QueryHandler(bCtx *env.BubblyContext, m *nats.Msg) error {
 		Msg("processing message")
 
 	result := d.Store.Query(string(m.Data))
+
+	if result.HasErrors() {
+		return fmt.Errorf("error while querying the data store: %v", result.Errors)
+	}
 	resultBytes, err := json.Marshal(result)
 
 	if err != nil {

--- a/agent/component/subscribe.go
+++ b/agent/component/subscribe.go
@@ -41,7 +41,6 @@ type Subject string
 // Any Subjects that components use to communicate with one another should be
 // defined centrally here
 const (
-	StoreGetResource        Subject = "store.GetResource"
 	StoreGetResourcesByKind Subject = "store.GetResourcesByKind"
 	StorePostResource       Subject = "store.PostResource"
 	StorePostSchema         Subject = "store.PostSchema"

--- a/server/resource.go
+++ b/server/resource.go
@@ -138,28 +138,4 @@ func (s *Server) GetResource(c echo.Context) error {
 	}
 
 	return c.JSONBlob(http.StatusOK, resultBytes)
-
-	// var result interface{}
-	// err = json.Unmarshal(resultBytes, &result)
-	// if err != nil {
-	// 	return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error unmarshalling resource: %w", err))
-	// }
-	// if result == nil || result.(map[string]interface{})[core.ResourceTableName] == nil {
-	// 	return c.JSON(http.StatusOK, core.ResourceBlockJSON{})
-	// }
-	//
-	// var (
-	// 	resJSON  core.ResourceBlockJSON
-	// 	inputMap = result.(map[string]interface{})[core.ResourceTableName].([]interface{})
-	// )
-	// b, err := json.Marshal(inputMap[0])
-	// if err != nil {
-	// 	return echo.NewHTTPError(http.StatusInternalServerError, "failed to marshal resource: ", err.Error())
-	// }
-	// err = json.Unmarshal(b, &resJSON)
-	// if err != nil {
-	// 	return echo.NewHTTPError(http.StatusInternalServerError, "failed to unmarshal resource: ", err.Error())
-	// }
-	//
-	// return c.JSON(http.StatusOK, resJSON)
 }


### PR DESCRIPTION
The problem is relatively straightforward: your awesome client refactoring assumes that the clients' respective `GetResource` methods take and return the same content, which unfortunately wasn't true. Now it should:

input = resource ID
output = `core.resourceBlockJSON`