### PR TITLE
Bug? Multiple instance being returned for record with multiple joins

### DIFF
--- a/store/datatree.go
+++ b/store/datatree.go
@@ -33,22 +33,26 @@ func (t dataTree) traverse(bCtx *env.BubblyContext, fn visitFn) (core.DataBlocks
 func visitNode(bCtx *env.BubblyContext, node *dataNode, fn visitFn, blocks *core.DataBlocks) error {
 	// First check that all the parents have been visited because we cannot
 	// solve a node until all its parents have been solved
+	var parentsVisited = true
 	for _, parent := range node.Parents {
 		if !parent.Visited {
-			if err := visitNode(bCtx, parent, fn, blocks); err != nil {
-				return err
-			}
+			parentsVisited = false
+			break
 		}
 	}
-	// Visit the node with the callback method
-	if err := fn(bCtx, node, blocks); err != nil {
-		return err
-	}
-	// If no error, mark the node as visited
-	node.Visited = true
-	for _, child := range node.Children {
-		if err := visitNode(bCtx, child, fn, blocks); err != nil {
+	// Check that parents have been visited and that the node is not being
+	// visited more than once
+	if parentsVisited && !node.Visited {
+		// Visit the node with the callback method
+		if err := fn(bCtx, node, blocks); err != nil {
 			return err
+		}
+		// If no error, mark the node as visited
+		node.Visited = true
+		for _, child := range node.Children {
+			if err := visitNode(bCtx, child, fn, blocks); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/store/graphql.go
+++ b/store/graphql.go
@@ -86,6 +86,22 @@ func newGraphQLSchema(graph *schemaGraph, s *Store) (graphql.Schema, error) {
 	return graphql.NewSchema(cfg)
 }
 
+// Support for order_by argument
+var orderByType = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "order_by",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"table": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+		"field": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+		"order": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+	},
+})
+
 // addGraphFields updates the `gqlField` map containing GraphQL Field definitions
 // with information for every field of the Table `t`, which is a table coming
 // from the Bubbly Schema.
@@ -117,6 +133,9 @@ func addGraphFields(t core.Table, fields map[string]gqlField) {
 	}
 	gqlField.Args[limitID] = &graphql.ArgumentConfig{
 		Type: graphql.Int,
+	}
+	gqlField.Args[orderByID] = &graphql.ArgumentConfig{
+		Type: graphql.NewList(orderByType),
 	}
 
 	// Create a GraphQL type for the current table so that we

--- a/store/graphql.go
+++ b/store/graphql.go
@@ -10,6 +10,12 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+//
+// The GraphQL Schema is a representation of the Bubbly Schema Graph,
+// enabling GraphQL access to Bubbly.
+//
+
+// graphJoinDistance ???
 const graphJoinDistance = 3
 
 // gqlField is our custom Graphql Field type so that we can store a field in
@@ -26,6 +32,7 @@ type gqlField struct {
 // newGraphQLSchema creates a new GraphQL schema wrapping the given provider
 // with a schema that corresponds to the given set of tables.
 func newGraphQLSchema(graph *schemaGraph, s *Store) (graphql.Schema, error) {
+
 	var (
 		fields = make(map[string]gqlField)
 		// These are the top-level query fields. Each of these fields
@@ -42,6 +49,7 @@ func newGraphQLSchema(graph *schemaGraph, s *Store) (graphql.Schema, error) {
 		addGraphFields(*node.table, fields)
 		return nil
 	})
+
 	// Create the relationships among the types using graph neighbours within
 	// a certain distance of each other
 	graph.traverse(func(node *schemaNode) error {
@@ -120,6 +128,7 @@ func addGraphFields(t core.Table, fields map[string]gqlField) {
 	fields[t.Name] = gqlField
 }
 
+// addGraphEdges ???
 func addGraphEdges(t core.Table, paths []schemaPath, fields map[string]gqlField) {
 	var field = fields[t.Name]
 	for _, path := range paths {
@@ -141,6 +150,7 @@ func addGraphEdges(t core.Table, paths []schemaPath, fields map[string]gqlField)
 	}
 }
 
+// graphQLFieldType ???
 func graphQLFieldType(f core.TableField) *graphql.Scalar {
 	switch ty := f.Type; {
 	case ty == cty.Bool:
@@ -182,6 +192,7 @@ var listFilters = []string{
 	filterNotIn,
 }
 
+// graphQLFilterType ???
 func graphQLFilterType(typeName string, args graphql.FieldConfigArgument) *graphql.InputObject {
 	var (
 		// Micro-opt: we know the size of the field map is the total number
@@ -210,14 +221,16 @@ func graphQLFilterType(typeName string, args graphql.FieldConfigArgument) *graph
 	)
 }
 
+// isValidValue ???
 func isValidValue(value interface{}) bool {
+
 	if value == nil {
 		return false
 	}
 
+	// graphql-go passes nil maps as empty values
 	if val, ok := value.(map[string]interface{}); ok {
 		if len(val) == 0 {
-			// graphql-go passes nil maps as empty values
 			return false
 		}
 	}
@@ -225,6 +238,7 @@ func isValidValue(value interface{}) bool {
 	return true
 }
 
+// parseValueToMap ???
 func parseValueToMap(astValue ast.Value) interface{} {
 	switch astValue.GetKind() {
 	case kinds.StringValue:
@@ -258,6 +272,7 @@ func parseValueToMap(astValue ast.Value) interface{} {
 	}
 }
 
+// FIXME: what's going on here?
 var mapScalar = graphql.NewScalar(graphql.ScalarConfig{
 	Name:        "Map",
 	Description: "The `Map` scalar type represents a Map for storing key/value pairs",

--- a/store/graphqlargs_test.go
+++ b/store/graphqlargs_test.go
@@ -1,0 +1,190 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/kinds"
+)
+
+// ########################################################################
+// OrderBy - RECOMMENDED!
+// This is more structured, and therefore much easier on our part, and the below
+// is the only "custom" stuff you need.
+// It adds a little overhead on the query side, but it's just so simple you cannot
+// fault it :)
+// ########################################################################
+var orderByItem = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "order_by",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"table": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+		"field": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+		"order": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+	},
+})
+
+// ########################################################################
+// OrderBy2 - Original, more difficult to parse
+// This is less structured by Graphql standards, and therefore more effort on our end.
+// We need to know the fields in a field map, and this will not work with aliases...
+// ########################################################################
+func orderByArgType(fields []string) *graphql.InputObject {
+	fieldMap := graphql.InputObjectConfigFieldMap{}
+	for _, field := range fields {
+		fieldMap[field] = &graphql.InputObjectFieldConfig{
+			Type: keyValue,
+		}
+	}
+	return graphql.NewInputObject(graphql.InputObjectConfig{
+		Name:   "order_by2",
+		Fields: fieldMap,
+	})
+}
+
+var keyValue = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "KeyValue",
+	Description: "TODO",
+	Serialize: func(value interface{}) interface{} {
+		return value
+	},
+	ParseValue: func(value interface{}) interface{} {
+		return value
+	},
+	ParseLiteral: func(astValue ast.Value) interface{} {
+		if astValue.GetKind() != kinds.ObjectValue {
+			return nil
+		}
+		var (
+			objFields = astValue.GetValue().([]*ast.ObjectField)
+			obj       = make(map[string]interface{}, len(objFields))
+		)
+		for _, v := range objFields {
+			switch v.Value.GetKind() {
+			case kinds.StringValue, kinds.BooleanValue, kinds.IntValue, kinds.FloatValue:
+				obj[v.Name.Value] = v.Value.GetValue()
+			default:
+				return nil
+			}
+		}
+		return obj
+	},
+})
+
+// ########################################################################
+// OrderBy3 - Original, just a variation this time with no structure
+// We could post validate this, but yeah, extra work
+// ########################################################################
+func orderByItemParseLiteral(astValue ast.Value) interface{} {
+	kind := astValue.GetKind()
+
+	switch kind {
+	case kinds.StringValue:
+		return astValue.GetValue()
+	case kinds.BooleanValue:
+		return astValue.GetValue()
+	case kinds.IntValue:
+		return astValue.GetValue()
+	case kinds.FloatValue:
+		return astValue.GetValue()
+	case kinds.ObjectValue:
+		obj := make(map[string]interface{})
+		for _, v := range astValue.GetValue().([]*ast.ObjectField) {
+			obj[v.Name.Value] = orderByItemParseLiteral(v.Value)
+		}
+		return obj
+	default:
+		// Indicates an error by returning nil, e.g Lists are not supported
+		return nil
+	}
+}
+
+var orderByItemUnstructured = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "OrderByStruct",
+	Description: "TODO",
+	Serialize: func(value interface{}) interface{} {
+		return value
+	},
+	ParseValue: func(value interface{}) interface{} {
+		return value
+	},
+	ParseLiteral: orderByItemParseLiteral,
+})
+
+// ########################################################################
+// TEST CASES
+// ########################################################################
+
+var queries = []struct {
+	query string
+}{
+	{
+		query: `
+		query {
+			test_run(order_by: [{table: "network", field: "name", order: "ASC"}])
+		}
+	`,
+	},
+	{
+		query: `
+		query {
+			test_run(order_by2: [{network: {asd: "asd"}}])
+		}
+	`,
+	},
+	{
+		query: `
+		query {
+			test_run(order_by3: [{network: {asd: "asd"}}])
+		}
+	`,
+	},
+}
+
+func TestGraphql(t *testing.T) {
+	// Schema
+	fields := graphql.Fields{
+		"test_run": &graphql.Field{
+			Args: graphql.FieldConfigArgument{
+				"order_by": &graphql.ArgumentConfig{Type: graphql.NewList(orderByItem)},
+				// TODO: you will need to create a list of the possible fields here that you could order by...
+				// What if there are custom aliases?? This will not work, right?
+				"order_by2": &graphql.ArgumentConfig{Type: graphql.NewList(orderByArgType([]string{"network", "test_case"}))},
+				"order_by3": &graphql.ArgumentConfig{Type: graphql.NewList(orderByItemUnstructured)},
+			},
+			Type: graphql.String,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				fmt.Printf("Args: %#v\n", p.Args["order_by"])
+				return "world", nil
+			},
+		},
+	}
+	queryType := graphql.NewObject(graphql.ObjectConfig{
+		Name:   "query",
+		Fields: fields,
+	})
+	schemaConfig := graphql.SchemaConfig{Query: queryType}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		t.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	for _, query := range queries {
+		params := graphql.Params{Schema: schema, RequestString: query.query}
+		r := graphql.Do(params)
+		if len(r.Errors) > 0 {
+			log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+		}
+		rJSON, _ := json.Marshal(r)
+		fmt.Printf("%s \n", rJSON)
+	}
+}

--- a/store/postgres_graphql.go
+++ b/store/postgres_graphql.go
@@ -142,8 +142,8 @@ func psqlSubQuery(graph *schemaGraph, qb *sqlQueryBuilder, tc *tableColumns, fie
 
 	// Create the tableColumns for this type/table in the query
 	var (
-		node = qb.node
-		// tb   = qb.columns
+		node      = qb.node
+		subFields = make([]*ast.Field, 0)
 	)
 
 	// FIXME: Why is the depth being increased here?
@@ -193,7 +193,6 @@ func psqlSubQuery(graph *schemaGraph, qb *sqlQueryBuilder, tc *tableColumns, fie
 
 	// Iterate over the fields in the selection set (if any) for the current `field`
 	for _, selection := range field.SelectionSet.Selections {
-
 		// Only GraphQL `Field`s are supported at this point. http://spec.graphql.org/June2018/#sec-Language.Fields
 		// The `Selection` interface is implemented by the `ast.Field` type in this supported case.
 		subField, ok := selection.(*ast.Field)
@@ -214,63 +213,14 @@ func psqlSubQuery(graph *schemaGraph, qb *sqlQueryBuilder, tc *tableColumns, fie
 			continue
 		}
 
-		// A non-nil selection set implies that the subField refers to another table in our schema.
+		// A non-nil selection set implies that the subField refers to another
+		// table in our schema.
+		// We need to process the columns/fields for this table first, before we
+		// process any subFields, so simply append these to a slice and process
+		// at the end of the function
 		if subField.SelectionSet != nil {
+			subFields = append(subFields, subField)
 
-			// TODO: instead of searching the graph, check the node's edges for their destinations, and use those dest. in JOINs
-			// In the following example, the current qb.node is `A`, and subField is `B`, and we have just discovered, that `B`
-			// refers to another table.
-			//
-			// A {
-			//     name
-			//     B {
-			//        name
-			//     }
-			// }
-
-			// Are the parent field and the subfield connected in the graph at all?
-			var edgeToRelatedNode *schemaEdge
-			for _, p := range node.edges {
-				if p.node.table.Name == fieldName {
-					edgeToRelatedNode = p
-				}
-			}
-			if edgeToRelatedNode == nil {
-				return fmt.Errorf("no relationship found between tables: '%s', '%s'", node.table.Name, fieldName)
-			}
-
-			var (
-				leftTable       = tc.table
-				leftTableAlias  = tc.alias
-				rightTable      = edgeToRelatedNode.node.table.Name
-				rightTableAlias = tableAlias(rightTable, qb.depth)
-			)
-
-			switch edgeToRelatedNode.rel {
-			case oneToOne, oneToMany:
-				qb.sql = qb.sql.LeftJoin(joinOn(
-					tableAsAlias(rightTable, rightTableAlias),
-					tableColumn(leftTableAlias, tableIDField),
-					tableColumn(rightTableAlias, foreignKeyField(leftTable))))
-			case belongsTo:
-				qb.sql = qb.sql.LeftJoin(
-					joinOn(
-						tableAsAlias(rightTable, rightTableAlias),
-						tableColumn(rightTableAlias, tableIDField),
-						tableColumn(leftTableAlias, foreignKeyField(rightTable))))
-			}
-
-			// Recursively resolve for the subField `B`, which may contain further nested fields.
-			qb.node = graph.nodeIndex[fieldName]
-			subColumns := &tableColumns{
-				table:  fieldName,
-				alias:  tableAlias(fieldName, qb.depth),
-				scalar: edgeToRelatedNode.isScalar(),
-			}
-			if err := psqlSubQuery(graph, qb, subColumns, subField, path); err != nil {
-				return err
-			}
-			tc.children = append(tc.children, subColumns)
 			continue
 		} else {
 			// If subField did not have a selection set this it is just a column
@@ -279,7 +229,67 @@ func psqlSubQuery(graph *schemaGraph, qb *sqlQueryBuilder, tc *tableColumns, fie
 			qb.sql = qb.sql.Column(tableColumn(tc.alias, fieldName))
 		}
 	}
+	// Once we have processed this fields columns, proceed to the subFields.
+	// This is to ensure the correct order of columns in the SQL SELECT statement
+	for _, subField := range subFields {
 
+		// TODO: instead of searching the graph, check the node's edges for their destinations, and use those dest. in JOINs
+		// In the following example, the current qb.node is `A`, and subField is `B`, and we have just discovered, that `B`
+		// refers to another table.
+		//
+		// A {
+		//     name
+		//     B {
+		//        name
+		//     }
+		// }
+
+		// Are the parent field and the subfield connected in the graph at all?
+		var (
+			fieldName         = subField.Name.Value
+			edgeToRelatedNode *schemaEdge
+		)
+		for _, p := range node.edges {
+			if p.node.table.Name == fieldName {
+				edgeToRelatedNode = p
+			}
+		}
+		if edgeToRelatedNode == nil {
+			return fmt.Errorf("no relationship found between tables: '%s', '%s'", node.table.Name, fieldName)
+		}
+
+		var (
+			leftTable       = tc.table
+			leftTableAlias  = tc.alias
+			rightTable      = edgeToRelatedNode.node.table.Name
+			rightTableAlias = tableAlias(rightTable, qb.depth)
+		)
+		switch edgeToRelatedNode.rel {
+		case oneToOne, oneToMany:
+			qb.sql = qb.sql.LeftJoin(joinOn(
+				tableAsAlias(rightTable, rightTableAlias),
+				tableColumn(leftTableAlias, tableIDField),
+				tableColumn(rightTableAlias, foreignKeyField(leftTable))))
+		case belongsTo:
+			qb.sql = qb.sql.LeftJoin(
+				joinOn(
+					tableAsAlias(rightTable, rightTableAlias),
+					tableColumn(rightTableAlias, tableIDField),
+					tableColumn(leftTableAlias, foreignKeyField(rightTable))))
+		}
+
+		// Recursively resolve for the subField `B`, which may contain further nested fields.
+		qb.node = graph.nodeIndex[fieldName]
+		subColumns := &tableColumns{
+			table:  fieldName,
+			alias:  tableAlias(fieldName, qb.depth),
+			scalar: edgeToRelatedNode.isScalar(),
+		}
+		if err := psqlSubQuery(graph, qb, subColumns, subField, path); err != nil {
+			return err
+		}
+		tc.children = append(tc.children, subColumns)
+	}
 	return nil
 }
 

--- a/store/schema.go
+++ b/store/schema.go
@@ -8,38 +8,50 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func newBubblySchema() *bubblySchema {
-	schema := &bubblySchema{
-		Tables: make(map[string]core.Table),
-	}
-	// Populate the fresh schema with the internal tables
-	for _, t := range internalTables {
-		schema.Tables[t.Name] = t
-	}
-	return schema
-}
+//
+// The Bubbly Schema is an abstraction describing the database tables
+// containing the user data and Bubbly's internal data structures,
+// as well as the connections between them.
+//
 
-// bubblySchema contains the bubblySchema in a useable form, which is currently
-// a map of the tables.
-// This should be extended in the future to accommodate for schema diffing
-// and other neat tricks.
+// bubblySchema contains the bubblySchema in a useable form, which is
+// currently a map of the tables. It also contains a list of expected
+// changes that will be applied by the migration.
 type bubblySchema struct {
 	Tables    map[string]core.Table
 	Changelog Changelog
 }
 
-// Data returns a core.Data value of the schema so that it can be saved in the
-// store just like any other data.
+// newBubblySchema makes an empty data structure, representing
+// a new Bubbly Schema, and then populates it with the minimum
+// set of tables necessary for Bubbly to work.
+func newBubblySchema() *bubblySchema {
+
+	schema := &bubblySchema{
+		Tables: make(map[string]core.Table, len(internalTables)),
+	}
+
+	for _, t := range internalTables {
+		schema.Tables[t.Name] = t
+	}
+
+	return schema
+}
+
+// Data returns a representation of the Bubbly Schema in a format,
+// suitable for saving it in the Store, just like any other data.
 func (b *bubblySchema) Data() (core.Data, error) {
+
 	bTables, err := json.Marshal(b.Tables)
+
 	if err != nil {
 		return core.Data{}, fmt.Errorf("failed to convert bubblySchema into data blocks: %w", err)
 	}
+
 	return core.Data{
 		TableName: core.SchemaTableName,
 		Fields: map[string]cty.Value{
-			// "Smuggle" the json as a string
-			"tables": cty.StringVal(string(bTables)),
+			"tables": cty.StringVal(string(bTables)), // "Smuggle" the JSON as a string
 		},
 	}, nil
 }

--- a/store/schemagraph.go
+++ b/store/schemagraph.go
@@ -6,6 +6,10 @@ import (
 	"github.com/valocode/bubbly/api/core"
 )
 
+//
+// The Schema Graph is a graph representation of the Bubbly Schema.
+//
+
 // relType describes the relationship type of a directed edge from a --> b
 type relType int
 
@@ -179,8 +183,13 @@ func (p *schemaPath) isScalar() bool {
 	return isScalar
 }
 
-// newSchemaGraphFromMap is a wrapper around newSchemaGraph for backwards
-// compatibility with the current way the schema is stored in the provider
+// newSchemaGraphFromMap returns a new Schema Graph,
+// created from the tables coming from the Bubbly Schema.
+//
+// It is implemented as a wrapper around newSchemaGraph for backwards
+// compatibility with the current way the schema is stored in the provider.
+//
+// FIXME: This project is too young to have "backwards compatibility" layer!
 func newSchemaGraphFromMap(tables map[string]core.Table) (*schemaGraph, error) {
 	var ts = make(core.Tables, 0, len(tables))
 	for _, t := range tables {
@@ -189,7 +198,8 @@ func newSchemaGraphFromMap(tables map[string]core.Table) (*schemaGraph, error) {
 	return newSchemaGraph(ts)
 }
 
-// newSchemaGraph takes a list of tables and creates a schemaGraph.
+// newSchemaGraph returns a new Schema Graph,
+// created from the tables coming from the Bubbly Schema.
 func newSchemaGraph(tables core.Tables) (*schemaGraph, error) {
 
 	var (

--- a/store/schemagraph_test.go
+++ b/store/schemagraph_test.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valocode/bubbly/env"
 	testData "github.com/valocode/bubbly/store/testdata"
 )
 
@@ -26,7 +28,11 @@ func printSchemaNode(node *schemaNode, depth int) {
 }
 
 func TestSchemaGraph(t *testing.T) {
-	tables := testData.Tables(t, filepath.FromSlash("testdata/tables.hcl"))
+
+	bCtx := env.NewBubblyContext()
+	bCtx.UpdateLogLevel(zerolog.DebugLevel)
+
+	tables := testData.Tables(t, bCtx, filepath.FromSlash("testdata/tables.hcl"))
 	graph, err := newSchemaGraph(tables)
 	require.NoErrorf(t, err, "failed to create schema graph")
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -528,6 +528,205 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "graphql order_by totoro asc",
+		schema: "tables6.hcl",
+		data:   "data6.hcl",
+		query: `
+		{
+			hideaways(location: "Deep Dark Wood",
+				order_by: [
+					{table: "characters", field: "name", order: "ASC"}
+				]) {
+				location
+				ready
+				distance_from_x
+				crew {
+					count
+					characters {
+						name
+					}
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"hideaways": []interface{}{
+				map[string]interface{}{
+					"location":        "Deep Dark Wood",
+					"distance_from_x": 1500,
+					"ready":           true,
+					"crew": []interface{}{
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chibi-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chuu-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Oh-Totoro",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:   "graphql order_by totoro desc",
+		schema: "tables6.hcl",
+		data:   "data6.hcl",
+		query: `
+		{
+			hideaways(location: "Deep Dark Wood",
+				order_by: [
+					{table: "characters", field: "name", order: "DESC"}
+				]) {
+				location
+				ready
+				distance_from_x
+				crew {
+					count
+					characters {
+						name
+					}
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"hideaways": []interface{}{
+				map[string]interface{}{
+					"location":        "Deep Dark Wood",
+					"distance_from_x": 1500,
+					"ready":           true,
+					"crew": []interface{}{
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Oh-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chuu-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chibi-Totoro",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:   "graphql order_by full house",
+		schema: "tables6.hcl",
+		data:   "data6.hcl",
+		query: `
+		{
+			hideaways(
+				order_by: [
+					{table: "hideaways", field: "location", order: "DESC"}
+					{table: "crew", field: "count", order: "DESC"}
+					{table: "characters", field: "name", order: "ASC"}
+				]) {
+				location
+				ready
+				distance_from_x
+				crew {
+					count
+					characters {
+						name
+					}
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"hideaways": []interface{}{
+				map[string]interface{}{
+					"location":        "Secret Underground Facility on the Moon",
+					"distance_from_x": 384400,
+					"ready":           true,
+					"crew": []interface{}{
+						map[string]interface{}{
+							"count": 42,
+							"characters": map[string]interface{}{
+								"name": "Little Green Man",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Little Green Man Leader",
+							},
+						},
+					},
+				},
+				map[string]interface{}{
+					"location":        "Gold Coast Villa",
+					"distance_from_x": 12500,
+					"ready":           false,
+					"crew": []interface{}{
+						map[string]interface{}{
+							"count": 2,
+							"characters": map[string]interface{}{
+								"name": "Smol European Mouse",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Old Horse with Shady Past",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Wombat",
+							},
+						},
+					},
+				},
+				map[string]interface{}{
+					"location":        "Deep Dark Wood",
+					"distance_from_x": 1500,
+					"ready":           true,
+					"crew": []interface{}{
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chibi-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Chuu-Totoro",
+							},
+						},
+						map[string]interface{}{
+							"count": 1,
+							"characters": map[string]interface{}{
+								"name": "Oh-Totoro",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -481,6 +481,34 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "graphql order_by 1",
+		schema: "tables5.hcl",
+		data:   "data5.hcl",
+		query: `
+		{
+			test_run(order_by: [{location: {name: ASC}}, {configuration: {name: DESC}}]) {
+				configuration {
+					name
+				}
+				location(name: "Deep Dark Wood") {
+					name
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"location": map[string]interface{}{
+						"name": "Deep Dark Wood",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Primitive",
+					},
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -941,7 +941,6 @@ func TestPostgresReinitialisation(t *testing.T) {
 	// this should return the schema that was formed from applySchemaOrDie,
 	// _not_ the baseSchema at row 0 in the _schema table
 	require.NotEqual(t, baseSchema, newSchema)
-
 }
 
 // TODO: extract into a helper as a similar block of code is used elsewhere in store (?) tests

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -388,14 +388,16 @@ var sqlGenTests = []struct {
 		query: `
 		{
 			test_run {
-				ok
-				location {
-					name
-				}
 				configuration {
 					name
 				}
-				version { name }
+				location {
+					name
+				}
+				ok
+				version {
+					name
+				}
 			}
 		}`,
 		want: map[string]interface{}{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -402,7 +402,7 @@ var sqlGenTests = []struct {
 						"name": "Deep Dark Wood",
 					},
 					"configuration": map[string]interface{}{
-						"name": "Advanced",
+						"name": "Primitive",
 					},
 					/*
 						"version": map[string]interface{}{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -905,9 +905,11 @@ func TestPostgresReinitialisation(t *testing.T) {
 	// feign re-initialisation of the Store, which should fetch the latest
 	// applied schema (from applySchemaOrDie)
 	s, err = New(bCtx)
+	require.NoError(t, err)
 
 	newSchema, err := s.currentBubblySchema()
-
+	require.NoError(t, err)
+	
 	// this should return the schema that was formed from applySchemaOrDie,
 	// _not_ the baseSchema at row 0 in the _schema table
 	require.NotEqual(t, baseSchema, newSchema)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -395,6 +395,7 @@ var sqlGenTests = []struct {
 				configuration {
 					name
 				}
+				version { name }
 			}
 		}`,
 		want: map[string]interface{}{
@@ -407,11 +408,9 @@ var sqlGenTests = []struct {
 					"configuration": map[string]interface{}{
 						"name": "Primitive",
 					},
-					/*
-						"version": map[string]interface{}{
-							"name": "v1.0.1",
-						},
-					*/
+					"version": map[string]interface{}{
+						"name": "v1.0.1",
+					},
 				},
 			},
 		},

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -487,17 +487,36 @@ var sqlGenTests = []struct {
 		data:   "data5.hcl",
 		query: `
 		{
-			test_run(order_by: [{location: {name: ASC}}, {configuration: {name: DESC}}]) {
+			test_run(order_by: [
+				{table: "location", field: "name", order: "DESC"}, 
+				{table: "configuration", field: "name", order: "DESC"}
+				]) {
 				configuration {
 					name
 				}
-				location(name: "Deep Dark Wood") {
+				location {
 					name
 				}
 			}
 		}`,
 		want: map[string]interface{}{
 			"test_run": []interface{}{
+				map[string]interface{}{
+					"location": map[string]interface{}{
+						"name": "Secret Underground Facility on the Moon",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Magic",
+					},
+				},
+				map[string]interface{}{
+					"location": map[string]interface{}{
+						"name": "Gold Coast City Skyline",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Approved by Wombats",
+					},
+				},
 				map[string]interface{}{
 					"location": map[string]interface{}{
 						"name": "Deep Dark Wood",
@@ -812,6 +831,7 @@ func TestPostgresSQLGen(t *testing.T) {
 			have := s.Query(tt.query)
 			require.Emptyf(t, have.Errors, "failed to execute query %s", tt.name)
 			require.Equal(t, tt.want, have.Data, "query response is equal")
+			t.Logf("have: %#v", have)
 		})
 	}
 }
@@ -937,7 +957,7 @@ func TestPostgresReinitialisation(t *testing.T) {
 
 	newSchema, err := s.currentBubblySchema()
 	require.NoError(t, err)
-	
+
 	// this should return the schema that was formed from applySchemaOrDie,
 	// _not_ the baseSchema at row 0 in the _schema table
 	require.NotEqual(t, baseSchema, newSchema)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -401,10 +401,10 @@ var sqlGenTests = []struct {
 					"location": map[string]interface{}{
 						"name": "Deep Dark Wood",
 					},
+					"configuration": map[string]interface{}{
+						"name": "Advanced",
+					},
 					/*
-						"configuration": map[string]interface{}{
-							"name": "Advanced",
-						},
 						"version": map[string]interface{}{
 							"name": "v1.0.1",
 						},

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -382,7 +382,7 @@ var sqlGenTests = []struct {
 		},
 	},
 	{
-		name:   "order by",
+		name:   "graphql field order 1",
 		schema: "tables5.hcl",
 		data:   "data5.hcl",
 		query: `
@@ -391,7 +391,7 @@ var sqlGenTests = []struct {
 				configuration {
 					name
 				}
-				location {
+				location(name: "Deep Dark Wood") {
 					name
 				}
 				ok
@@ -412,6 +412,70 @@ var sqlGenTests = []struct {
 					},
 					"version": map[string]interface{}{
 						"name": "v1.0.1",
+					},
+				},
+			},
+		},
+	},
+	{
+		name:   "graphql field order 2",
+		schema: "tables5.hcl",
+		data:   "data5.hcl",
+		query: `
+		{
+			test_run {
+				ok
+				location(name: "Deep Dark Wood") {
+					name
+				}
+				version {
+					name
+				}
+				configuration {
+					name
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"ok": true,
+					"location": map[string]interface{}{
+						"name": "Deep Dark Wood",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Primitive",
+					},
+					"version": map[string]interface{}{
+						"name": "v1.0.1",
+					},
+				},
+			},
+		},
+	},
+	{
+		name:   "graphql field order 3",
+		schema: "tables5.hcl",
+		data:   "data5.hcl",
+		query: `
+		{
+			test_run {
+				configuration {
+					name
+				}
+				location(name: "Deep Dark Wood") {
+					name
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"location": map[string]interface{}{
+						"name": "Deep Dark Wood",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Primitive",
 					},
 				},
 			},

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/rs/zerolog"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -385,7 +386,7 @@ var sqlGenTests = []struct {
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {
 	t.Helper()
 
-	tables := testData.Tables(t, fromFile)
+	tables := testData.Tables(t, bCtx, fromFile)
 
 	err := s.Apply(bCtx, tables)
 	require.NoErrorf(t, err, "failed to apply schema")
@@ -394,7 +395,7 @@ func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile 
 func loadTestDataOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {
 	t.Helper()
 
-	data := testData.DataBlocks(t, fromFile)
+	data := testData.DataBlocks(t, bCtx, fromFile)
 
 	err := s.Save(bCtx, data)
 	require.NoErrorf(t, err, "failed to save test data into the store")
@@ -660,6 +661,9 @@ func TestPostgresSQLGen(t *testing.T) {
 
 			// Initialise the Bubbly context
 			bCtx := env.NewBubblyContext()
+			bCtx.UpdateLogLevel(zerolog.DebugLevel)
+
+			// Configure the Bubbly Store
 			bCtx.StoreConfig.Provider = config.PostgresStore
 			bCtx.StoreConfig.PostgresAddr = fmt.Sprintf("localhost:%s", resource.GetPort("5432/tcp"))
 			bCtx.StoreConfig.PostgresDatabase = postgresDatabase

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -381,6 +381,38 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "order by",
+		schema: "tables5.hcl",
+		data:   "data5.hcl",
+		query: `
+		{
+			test_run {
+				ok
+				location {
+					name
+				}
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"ok": true,
+					"location": map[string]interface{}{
+						"name": "Deep Dark Wood",
+					},
+					/*
+						"configuration": map[string]interface{}{
+							"name": "Advanced",
+						},
+						"version": map[string]interface{}{
+							"name": "v1.0.1",
+						},
+					*/
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -392,6 +392,9 @@ var sqlGenTests = []struct {
 				location {
 					name
 				}
+				configuration {
+					name
+				}
 			}
 		}`,
 		want: map[string]interface{}{

--- a/store/testdata/sqlgen/data5.hcl
+++ b/store/testdata/sqlgen/data5.hcl
@@ -16,17 +16,17 @@ data "configuration" {
 	}
 }
 
-// data "version" {
-// 	fields = {
-// 		"name": "v1.0.1"
-// 	}
-// }
+data "version" {
+	fields = {
+		"name": "v1.0.1"
+	}
+}
 
 data "test_run" {
 	joins = [
 		"location",
 		"configuration",
-//		"version",
+		"version",
 		]
 	fields = {
 		"ok": true

--- a/store/testdata/sqlgen/data5.hcl
+++ b/store/testdata/sqlgen/data5.hcl
@@ -35,34 +35,63 @@ data "test_run" {
 
 ### Entry 2
 
-// data "location" {
-// 	fields = {
-// 		"name": "Gold Coast City Skyline"
-// 	}
-// }
+data "location" {
+	fields = {
+		"name": "Gold Coast City Skyline"
+	}
+}
 
-// data "test_run" {
-// 	joins = [
-// 		"location"
-// 	]
-// 	fields = {
-// 		"ok": false
-// 	}
-// }
+data "configuration" {
+	fields = {
+		"name": "Approved by Wombats"
+	}
+}
+
+data "version" {
+	fields = {
+		"name": "v2.5"
+	}
+}
+
+
+data "test_run" {
+	joins = [
+		"version",
+		"configuration",
+		"location",
+	]
+	fields = {
+		"ok": false
+	}
+}
 
 ### Entry 3
 
-// data "location" {
-// 	fields = {
-// 		"name": "Secret Underground Facility on the Moon"
-// 	}
-// }
+data "location" {
+	fields = {
+		"name": "Secret Underground Facility on the Moon"
+	}
+}
 
-// data "test_run" {
-// 	joins = [
-// 		"location"
-// 	]
-// 	fields = {
-// 		"ok": true
-// 	}
-// }
+data "configuration" {
+	fields = {
+		"name": "Magic"
+	}
+}
+
+data "version" {
+	fields = {
+		"name": "X.Y.Z-1"
+	}
+}
+
+data "test_run" {
+	joins = [
+		"location",
+		"version",
+		"configuration",
+	]
+	fields = {
+		"ok": true
+	}
+}

--- a/store/testdata/sqlgen/data5.hcl
+++ b/store/testdata/sqlgen/data5.hcl
@@ -1,0 +1,68 @@
+#
+# Data for tables5.hcl
+#
+
+### Entry 1
+
+data "location" {	
+	fields = {
+		"name": "Deep Dark Wood"
+	}
+}
+
+data "configuration" {
+	fields = {
+		"name": "Primitive"
+	}
+}
+
+// data "version" {
+// 	fields = {
+// 		"name": "v1.0.1"
+// 	}
+// }
+
+data "test_run" {
+	joins = [
+		"location",
+		"configuration",
+//		"version",
+		]
+	fields = {
+		"ok": true
+	}
+}
+
+### Entry 2
+
+// data "location" {
+// 	fields = {
+// 		"name": "Gold Coast City Skyline"
+// 	}
+// }
+
+// data "test_run" {
+// 	joins = [
+// 		"location"
+// 	]
+// 	fields = {
+// 		"ok": false
+// 	}
+// }
+
+### Entry 3
+
+// data "location" {
+// 	fields = {
+// 		"name": "Secret Underground Facility on the Moon"
+// 	}
+// }
+
+// data "test_run" {
+// 	joins = [
+// 		"location"
+// 	]
+// 	fields = {
+// 		"ok": true
+// 	}
+// }

--- a/store/testdata/sqlgen/data6.hcl
+++ b/store/testdata/sqlgen/data6.hcl
@@ -1,0 +1,179 @@
+#
+# Data for tables6.hcl
+#
+
+### Hideaway 1
+
+data "hideaways" {	
+	fields = {
+		"location":         "Deep Dark Wood",
+		"sophistication":   "simple",
+		"distance_from_x":  1500,
+		"ready":            true,
+	}
+}
+
+# The Totoros are inserted into the DB out-of-order.
+# The ASC sorting order would be: Chibi-Totoro, Chuu-Totoro, Oh-Totoro
+# The DESC sorting order would be: Oh-Totoro, Chuu-Totoro, Chibi-Totoro
+# We insert: Chibi-Totoro, Chuu-Totoro, Oh-Totoro
+# In the absence of fuzzy testing, this should provide better assurance
+# that our order_by is working correctly.
+
+data "characters" {
+	fields = {
+		"name": "Oh-Totoro",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Chibi-Totoro",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Chuu-Totoro",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}
+
+### Hideaway 2
+
+data "hideaways" {	
+	fields = {
+		"location":         "Secret Underground Facility on the Moon",
+		"sophistication":   "incredible",
+		"distance_from_x":  384400,
+		"ready":            true,
+	}
+}
+
+# The Green Men are inserted into the DB in ASC order: 
+#  - "Little Green Man"
+#  - "Little Green Man Leader"
+# When sorted by (crew.count ASC, characters.name DESC),
+# the "Little Green Man Leader" would come before 
+# the "Little Green Man". This would be a check for ordering
+# not just on string values, but also on numbers.
+
+data "characters" {
+	fields = {
+		"name": "Little Green Man",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 42,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Little Green Man Leader",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}
+
+### Hideaway 3
+
+data "hideaways" {	
+	fields = {
+		"location":         "Gold Coast Villa",
+		"sophistication":   "average",
+		"distance_from_x":  12500,
+		"ready":            false,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Wombat",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Smol European Mouse",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 2,
+	}
+}
+
+data "characters" {
+	fields = {
+		"name": "Old Horse with Shady Past",
+	}
+}
+
+data "crew" {
+	joins = [
+		"hideaways",
+		"characters",
+		]
+	fields = {
+		"count": 1,
+	}
+}

--- a/store/testdata/sqlgen/tables5.hcl
+++ b/store/testdata/sqlgen/tables5.hcl
@@ -5,7 +5,7 @@ table "test_run" {
 
 	join "location" {}
 	join "configuration" {}
-	// join "version" {}
+	join "version" {}
 
 	field "ok" {
 		type = bool
@@ -26,9 +26,9 @@ table "configuration" {
 	}
 }
 
-// table "version" {
-// 	field "name" {
-// 		type = string
-// 		unique = true
-// 	}
-// }
+table "version" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}

--- a/store/testdata/sqlgen/tables5.hcl
+++ b/store/testdata/sqlgen/tables5.hcl
@@ -1,0 +1,34 @@
+#
+# Multi-row example with sibling fields.
+#
+table "test_run" {
+
+	join "location" {}
+	join "configuration" {}
+	// join "version" {}
+
+	field "ok" {
+		type = bool
+	}
+}
+
+table "location" {	
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "configuration" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+// table "version" {
+// 	field "name" {
+// 		type = string
+// 		unique = true
+// 	}
+// }

--- a/store/testdata/sqlgen/tables6.hcl
+++ b/store/testdata/sqlgen/tables6.hcl
@@ -1,0 +1,46 @@
+#
+# Multi-row, multi-table example for testing 
+# the `order_by` GraphQL argument.
+#
+
+# This example is about a crew of characters,
+# each crew housed in a hideaway.
+
+# NB: This was **not** meant as an example of excellent database design. 
+# It was built to provide the data necessary for testing, with a simple story.
+# To find out how we can help you manage your comprehensive hideways list please contact Sales.
+
+table "hideaways" {
+	field "location" {
+		type = string
+		unique = true
+	}
+
+	field "sophistication" {
+		type = string
+	}
+
+	field "distance_from_x" {
+		type = number
+	}
+
+	field "ready" {
+		type = bool
+	}
+}
+
+table "characters" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "crew" {
+	join "characters" {}
+	join "hideaways" {}
+
+	field "count" {
+		type = number
+	}
+}

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -11,30 +11,34 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func Tables(t *testing.T, fromFile string) core.Tables {
+func Tables(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.Tables {
 	t.Helper()
 
-	bCtx := env.NewBubblyContext()
 	tableWrapper := struct {
 		Tables core.Tables `hcl:"table,block"`
 	}{}
+
 	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse tables")
+
 	err = parser.DecodeExpandBody(bCtx, body, &tableWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode tables")
+
 	return tableWrapper.Tables
 }
 
-func DataBlocks(t *testing.T, fromFile string) core.DataBlocks {
+func DataBlocks(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.DataBlocks {
 	t.Helper()
 
-	bCtx := env.NewBubblyContext()
 	dataWrapper := struct {
 		Data core.DataBlocks `hcl:"data,block"`
 	}{}
+
 	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse data blocks")
+
 	err = parser.DecodeExpandBody(bCtx, body, &dataWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode data blocks")
+
 	return dataWrapper.Data
 }

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -40,6 +40,5 @@ func DataBlocks(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.Dat
 	err = parser.DecodeExpandBody(bCtx, body, &dataWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode data blocks")
 
-	bCtx.Logger.Debug().Interface("Data", dataWrapper.Data).Msg("This get loaded into the DB:")
 	return dataWrapper.Data
 }

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -40,5 +40,6 @@ func DataBlocks(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.Dat
 	err = parser.DecodeExpandBody(bCtx, body, &dataWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode data blocks")
 
+	bCtx.Logger.Debug().Interface("Data", dataWrapper.Data).Msg("This get loaded into the DB:")
 	return dataWrapper.Data
 }


### PR DESCRIPTION
Multiple record instances are being returned for record with multiple joins.

I've added a new (isolated) test sub-case to `TestPostgresSQLGen` to illustrate the problem.

You can run it with:

```shell
go test -timeout 120s -v -count=1 -run=TestPostgresSQLGen/order_by github.com/valocode/bubbly/store
```

Supporting files:

* schema in [`store/testdata/sqlgen/tables5.hcl`][schema]
* data in [`store/testdata/sqlgen/data5.hcl`][data]

[schema]: https://github.com/valocode/bubbly/blob/b1ea88509dcf8ea9b8e371e617d58dbb6b0ab7f5/store/testdata/sqlgen/tables5.hcl
[data]: https://github.com/valocode/bubbly/blob/b1ea88509dcf8ea9b8e371e617d58dbb6b0ab7f5/store/testdata/sqlgen/data5.hcl

If the number of `join`s is reduced to _one_, the problem goes away.

Bug? I suppose this one is for you, @jlarfors 🙃 

PS the changes to the `testdata.Tables` and `testdata.DataBlocks` are introduced after the problem had been identified. The changes are to facilitate logging of `DataBlocks` before they are saved into the Store. The previous versions of the test helpers created their own Bubbly Context, so the parameters set for the logger did not propagate into the helpers. 