### PR TITLE
Fix/store reinitilisation bug

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -252,7 +252,7 @@ func (s *Store) currentBubblySchema() (*bubblySchema, error) {
 	}
 
 	var schema bubblySchema
-	b, err := json.Marshal(val[0])
+	b, err := json.Marshal(val[len(val)-1])
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal graphql response: %w", err)
 	}


### PR DESCRIPTION
I discovered that if you tear down the bubbly worker and reinitialize, the Store will be reinitialised with the base schema that is established from the `internalTables` (so only containing `_event`, `_resource` and `_schema` tables) regardless of whether further schemas had been successfully applied to the store. 

This PR fixes the issue and adds a unit test to validate the fix and make sure this doesn't regress.