### PR TITLE
Update GitHub Actions to Go 1.16

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,8 +12,16 @@ on:
 name: integration
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.16.2]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: cache go mod
@@ -23,7 +31,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Integration tests
+      - name: Run integration tests
         run: |
           docker-compose up -d postgres bubbly
 

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       # matrix lets us expand our range of OSs / go
       matrix:
-        go-version: [1.15.5]
+        go-version: [1.16.2]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Updated both `simple` and `integration` workflows to use Go 1.16 from the build matrix. This is required by the PR #54.