### PR TITLE
Set ClientType for agent cmd only if agent command is actually run

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -53,9 +53,6 @@ type AgentOptions struct {
 
 // NewCmdAgent creates a new cobra.Command representing "bubbly agent"
 func NewCmdAgent(bCtx *env.BubblyContext) (*cobra.Command, *AgentOptions) {
-	// Set the ClientType as NATS, because all agents should run internally to
-	// bubbly and can talk directly to NATS
-	bCtx.ClientConfig.ClientType = config.NATSClientType
 
 	o := &AgentOptions{
 		BubblyContext: bCtx,
@@ -247,6 +244,9 @@ func (o *AgentOptions) Resolve() error {
 // and runs any activated bubbly agent component
 func (o *AgentOptions) Run() error {
 
+	// Set the ClientType as NATS, because all agents should run internally to
+	// bubbly and can talk directly to NATS
+	o.BubblyContext.ClientConfig.ClientType = config.NATSClientType
 	a := agent.New(o.BubblyContext)
 
 	if err := a.Run(o.BubblyContext); err != nil {


### PR DESCRIPTION
Previous version was buggy as it set the client type as NATS when initialising the
agent cmd... regardless of whether we were running as an agent or not.