### PR TITLE
Add a test and a fix for duplicate entries in GraphQL response.

### DIFF
--- a/store/datatree.go
+++ b/store/datatree.go
@@ -33,22 +33,26 @@ func (t dataTree) traverse(bCtx *env.BubblyContext, fn visitFn) (core.DataBlocks
 func visitNode(bCtx *env.BubblyContext, node *dataNode, fn visitFn, blocks *core.DataBlocks) error {
 	// First check that all the parents have been visited because we cannot
 	// solve a node until all its parents have been solved
+	var parentsVisited = true
 	for _, parent := range node.Parents {
 		if !parent.Visited {
-			if err := visitNode(bCtx, parent, fn, blocks); err != nil {
-				return err
-			}
+			parentsVisited = false
+			break
 		}
 	}
-	// Visit the node with the callback method
-	if err := fn(bCtx, node, blocks); err != nil {
-		return err
-	}
-	// If no error, mark the node as visited
-	node.Visited = true
-	for _, child := range node.Children {
-		if err := visitNode(bCtx, child, fn, blocks); err != nil {
+	// Check that parents have been visited and that the node is not being
+	// visited more than once
+	if parentsVisited && !node.Visited {
+		// Visit the node with the callback method
+		if err := fn(bCtx, node, blocks); err != nil {
 			return err
+		}
+		// If no error, mark the node as visited
+		node.Visited = true
+		for _, child := range node.Children {
+			if err := visitNode(bCtx, child, fn, blocks); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/store/datatree.go
+++ b/store/datatree.go
@@ -28,6 +28,21 @@ func (t dataTree) traverse(bCtx *env.BubblyContext, fn visitFn) (core.DataBlocks
 	return blocks, nil
 }
 
+// reset goes over the tree and resets the tree so that it can be traversed again
+func (t dataTree) reset() {
+	for _, n := range t {
+		resetDataNode(n)
+	}
+}
+
+// resetDataNode takes a node, resets it, and then calls itself for the node's children
+func resetDataNode(node *dataNode) {
+	node.Visited = false
+	for _, c := range node.Children {
+		resetDataNode(c)
+	}
+}
+
 // visitNode is a wrapper around the callback visit function to make sure that
 // all the nodes are visited at least once, and at most once
 func visitNode(bCtx *env.BubblyContext, node *dataNode, fn visitFn, blocks *core.DataBlocks) error {

--- a/store/schemagraph_test.go
+++ b/store/schemagraph_test.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valocode/bubbly/env"
 	testData "github.com/valocode/bubbly/store/testdata"
 )
 
@@ -26,7 +28,11 @@ func printSchemaNode(node *schemaNode, depth int) {
 }
 
 func TestSchemaGraph(t *testing.T) {
-	tables := testData.Tables(t, filepath.FromSlash("testdata/tables.hcl"))
+
+	bCtx := env.NewBubblyContext()
+	bCtx.UpdateLogLevel(zerolog.DebugLevel)
+
+	tables := testData.Tables(t, bCtx, filepath.FromSlash("testdata/tables.hcl"))
 	graph, err := newSchemaGraph(tables)
 	require.NoErrorf(t, err, "failed to create schema graph")
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -381,6 +381,40 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "order by",
+		schema: "tables5.hcl",
+		data:   "data5.hcl",
+		query: `
+		{
+			test_run {
+				ok
+				location {
+					name
+				}
+				configuration {
+					name
+				}
+				version { name }
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"ok": true,
+					"location": map[string]interface{}{
+						"name": "Deep Dark Wood",
+					},
+					"configuration": map[string]interface{}{
+						"name": "Primitive",
+					},
+					"version": map[string]interface{}{
+						"name": "v1.0.1",
+					},
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/testdata/sqlgen/data5.hcl
+++ b/store/testdata/sqlgen/data5.hcl
@@ -1,0 +1,68 @@
+#
+# Data for tables5.hcl
+#
+
+### Entry 1
+
+data "location" {	
+	fields = {
+		"name": "Deep Dark Wood"
+	}
+}
+
+data "configuration" {
+	fields = {
+		"name": "Primitive"
+	}
+}
+
+data "version" {
+	fields = {
+		"name": "v1.0.1"
+	}
+}
+
+data "test_run" {
+	joins = [
+		"location",
+		"configuration",
+		"version",
+		]
+	fields = {
+		"ok": true
+	}
+}
+
+### Entry 2
+
+// data "location" {
+// 	fields = {
+// 		"name": "Gold Coast City Skyline"
+// 	}
+// }
+
+// data "test_run" {
+// 	joins = [
+// 		"location"
+// 	]
+// 	fields = {
+// 		"ok": false
+// 	}
+// }
+
+### Entry 3
+
+// data "location" {
+// 	fields = {
+// 		"name": "Secret Underground Facility on the Moon"
+// 	}
+// }
+
+// data "test_run" {
+// 	joins = [
+// 		"location"
+// 	]
+// 	fields = {
+// 		"ok": true
+// 	}
+// }

--- a/store/testdata/sqlgen/tables5.hcl
+++ b/store/testdata/sqlgen/tables5.hcl
@@ -1,0 +1,34 @@
+#
+# Multi-row example with sibling fields.
+#
+table "test_run" {
+
+	join "location" {}
+	join "configuration" {}
+	join "version" {}
+
+	field "ok" {
+		type = bool
+	}
+}
+
+table "location" {	
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "configuration" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "version" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}

--- a/store/testdata/store_testdata.go
+++ b/store/testdata/store_testdata.go
@@ -11,30 +11,34 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func Tables(t *testing.T, fromFile string) core.Tables {
+func Tables(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.Tables {
 	t.Helper()
 
-	bCtx := env.NewBubblyContext()
 	tableWrapper := struct {
 		Tables core.Tables `hcl:"table,block"`
 	}{}
+
 	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse tables")
+
 	err = parser.DecodeExpandBody(bCtx, body, &tableWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode tables")
+
 	return tableWrapper.Tables
 }
 
-func DataBlocks(t *testing.T, fromFile string) core.DataBlocks {
+func DataBlocks(t *testing.T, bCtx *env.BubblyContext, fromFile string) core.DataBlocks {
 	t.Helper()
 
-	bCtx := env.NewBubblyContext()
 	dataWrapper := struct {
 		Data core.DataBlocks `hcl:"data,block"`
 	}{}
+
 	body, err := parser.MergedHCLBodies(bCtx, fromFile)
 	require.NoErrorf(t, err, "failed to parse data blocks")
+
 	err = parser.DecodeExpandBody(bCtx, body, &dataWrapper, cty.NilVal)
 	require.NoErrorf(t, err, "failed to decode data blocks")
+
 	return dataWrapper.Data
 }

--- a/store/triggers.go
+++ b/store/triggers.go
@@ -53,6 +53,8 @@ type trigger struct {
 // Once all triggers have been evaluated, the dataBlocks are converted
 // to a dataTree and returned to be saved to the store
 func HandleTriggers(bCtx *env.BubblyContext, tree dataTree, triggers []*trigger, kind Kind) (dataTree, error) {
+	// First make sure we reset the tree so that we can traverse it again
+	tree.reset()
 	triggerBlocks := core.DataBlocks{}
 	for _, t := range triggers {
 		if t.Kind != kind {


### PR DESCRIPTION
The test for the bug I had discovered while working on GraphQL argument and the fix provided by @jlarfors.

* Make Store test schema and data loaders context-aware.
* Add a test case illustrating a problem with duplicate results in GraphQL response.
* Fix logic behind traversing the datatree, to ensure that all nodes are visited once, only after all the parents have been visited

## ✔️ Commented-out HCL code

Please ignore the commented out HCL code in `data5.hcl`. It will be updated by the upcoming PRs. I'm building up a series of PRs by cherry-picking commits from a branch which had been introduced _before_ the multi-tenancy feature and has grown too big to be rebased in a single step.