### PR TITLE
Add distinct_on argument support to GraphQL and the tests for it.

### DIFF
--- a/store/graphql.go
+++ b/store/graphql.go
@@ -99,6 +99,19 @@ var orderByType = graphql.NewInputObject(graphql.InputObjectConfig{
 	},
 })
 
+// Support for distinct_on argument
+var distinctOnType = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "distinct_on",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"table": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+		"field": &graphql.InputObjectFieldConfig{
+			Type: graphql.String,
+		},
+	},
+})
+
 // addGraphFields updates the `gqlField` map containing GraphQL Field definitions
 // with information for every field of the Table `t`, which is a table coming
 // from the Bubbly Schema.
@@ -131,6 +144,10 @@ func addGraphFields(t core.Table, fields map[string]gqlField) {
 	}
 	gqlField.Args[orderByID] = &graphql.ArgumentConfig{
 		Type: graphql.NewList(orderByType),
+	}
+	// FIXME it would be great to define HERE that `distinct_on` requires `order_by`
+	gqlField.Args[distinctOnID] = &graphql.ArgumentConfig{
+		Type: graphql.NewList(distinctOnType),
 	}
 
 	// Create a GraphQL type for the current table so that we
@@ -186,9 +203,10 @@ func graphQLFieldType(f core.TableField) *graphql.Scalar {
 }
 
 const (
-	filterID  = "filter"
-	limitID   = "limit"
-	orderByID = "order_by"
+	filterID     = "filter"
+	limitID      = "limit"
+	orderByID    = "order_by"
+	distinctOnID = "distinct_on"
 )
 
 const (

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -727,6 +727,106 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "graphql distinct on latest",
+		schema: "tables7.hcl",
+		data:   "data7.hcl",
+		query: `
+		{
+			test_run(
+				order_by: [
+					{table: "location", field: "name", order: "ASC"},
+					{table: "configuration", field: "name", order: "ASC"},
+					{table: "version", field: "name", order: "ASC"},
+					{table: "test_run", field: "finish_epoch", order: "DESC"}
+				],
+				distinct_on: [
+					{table: "location", field: "name"},
+					{table: "configuration", field: "name"},
+					{table: "version", field: "name"},
+				]
+			) {
+				configuration {
+					name
+				}
+				location(name: "Oliver's NEON workstation") {
+					name
+				}
+				version {
+					name
+				}
+				ok
+				finish_epoch
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"ok":           true,
+					"finish_epoch": "1611111111",
+					"location": map[string]interface{}{
+						"name": "Oliver's NEON workstation",
+					},
+					"configuration": map[string]interface{}{
+						"name": "So-so",
+					},
+					"version": map[string]interface{}{
+						"name": "v1.0.1",
+					},
+				},
+			},
+		},
+	},
+	{
+		name:   "graphql distinct on first",
+		schema: "tables7.hcl",
+		data:   "data7.hcl",
+		query: `
+		{
+			test_run(
+				order_by: [
+					{table: "location", field: "name", order: "ASC"},
+					{table: "configuration", field: "name", order: "ASC"},
+					{table: "version", field: "name", order: "ASC"},
+					{table: "test_run", field: "finish_epoch", order: "ASC"}
+				],
+				distinct_on: [
+					{table: "location", field: "name"},
+					{table: "configuration", field: "name"},
+					{table: "version", field: "name"},
+				]
+			) {
+				configuration {
+					name
+				}
+				location(name: "Oliver's NEON workstation") {
+					name
+				}
+				version {
+					name
+				}
+				ok
+				finish_epoch
+			}
+		}`,
+		want: map[string]interface{}{
+			"test_run": []interface{}{
+				map[string]interface{}{
+					"ok":           false,
+					"finish_epoch": "1311111111",
+					"location": map[string]interface{}{
+						"name": "Oliver's NEON workstation",
+					},
+					"configuration": map[string]interface{}{
+						"name": "So-so",
+					},
+					"version": map[string]interface{}{
+						"name": "v1.0.1",
+					},
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/testdata/sqlgen/data7.hcl
+++ b/store/testdata/sqlgen/data7.hcl
@@ -1,0 +1,63 @@
+#
+# Data for tables7.hcl
+#
+
+### Set 1: multiple entries for (location, configuration, version)
+###        being ("Oliver's NEON workstation", "So-so", "v1.0.1"),
+###        with the most recent entry being "ok", and a mixed bag
+###        of results for the previous entries.
+
+data "location" {	
+	fields = {
+		"name": "Oliver's NEON workstation"
+	}
+}
+
+data "configuration" {
+	fields = {
+		"name": "So-so"
+	}
+}
+
+data "version" {
+	fields = {
+		"name": "v1.0.1"
+	}
+}
+
+# Latest `test_run` in this set
+data "test_run" {
+	joins = [
+		"location",
+		"configuration",
+		"version",
+		]
+	fields = {
+		"ok": true      
+		"finish_epoch": "1611111111"
+	}
+}
+
+data "test_run" {
+	joins = [
+		"location",
+		"configuration",
+		"version",
+		]
+	fields = {
+		"ok": false
+		"finish_epoch": "1311111111"
+	}
+}
+
+data "test_run" {
+	joins = [
+		"location",
+		"configuration",
+		"version",
+		]
+	fields = {
+		"ok": true
+		"finish_epoch": "1411111111"
+	}
+}

--- a/store/testdata/sqlgen/tables7.hcl
+++ b/store/testdata/sqlgen/tables7.hcl
@@ -1,0 +1,43 @@
+#
+# Multi-row example for testing `order_by` 
+# and `distinct_on` arguments working together.
+#
+table "test_run" {
+
+	join "location" {}
+	join "configuration" {}
+	join "version" {}
+
+	field "ok" {
+		type = bool
+	}
+
+	# UNIX epoch: https://www.epochconverter.com/
+	# This indicates when the test run finished.
+	# For the test_run records tied at (location, configuration, version),
+	# the most recent one is the one with the greatest finish_epoch value.
+	field "finish_epoch" {
+		type = string
+	}
+}
+
+table "location" {	
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "configuration" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}
+
+table "version" {
+	field "name" {
+		type = string
+		unique = true
+	}
+}


### PR DESCRIPTION
This is the second part of GraphQL improvements necessary to support selecting the most/least recent entry in each partition of data in the GraphQL query.

The `distinct_on` argument requires `order_by` argument support for which has already been merged into `main`.

With the feature provided by this PR, the root types in a GraphQL query can be partitioned using `order_by`, with the most recent or least recent entry in a partition being select by the `distinct_on` argument.

In the following example, the most recent version of the `test_run` will be selected for 
every choice of `(location, configuration, version)` tuple:

```graphql
test_run(
  order_by: [
    {table: "location", field: "name", order: "ASC"},
    {table: "configuration", field: "name", order: "ASC"},
    {table: "version", field: "name", order: "ASC"},
    {table: "test_run", field: "finish_epoch", order: "DESC"}
  ],
  distinct_on: [
    {table: "location", field: "name"},
    {table: "configuration", field: "name"},
    {table: "version", field: "name"},
  ]
) {
    configuration {
      name
    }
    location(name: "Oliver's NEON workstation") {
      name
    }
    version {
      name
    }
    ok
    finish_epoch
  }
```