### PR TITLE
.github/workflows/integration.yaml: Take gosec into use

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -38,4 +38,8 @@ jobs:
           # just sleep a bit to wait for the containers to start
           sleep 1
           docker-compose logs
-          go test ./... -tags=integration -count=1
+          go test ./... -tags=integration -count=1 -json | tee integration.json
+      - name: Run Gosec Security Scanner
+        run: |
+          curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+          gosec -fmt json -no-fail -out out.json ./...


### PR DESCRIPTION
Have gosec, snyk , unit tests and integration tests running in our GitHub actions workflows and results captured with Bubbly into generic tables. 

Quote from Jacob:
> E.g. we don't want snyk_vulnerability  but instead something like table "cve" { ... } , and then it doesn't matter if you run snyk or some other tool and the goal of the pipeline is to standardise all the results so that we can use them for "release readiness"

