### PR TITLE
Add (a very limited) limit argument support to GraphQL

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -827,6 +827,32 @@ var sqlGenTests = []struct {
 			},
 		},
 	},
+	{
+		name:   "graphql limit on root",
+		schema: "tables8.hcl",
+		data:   "data8.hcl",
+		query: `
+		{
+			events(
+				order_by: [
+					{table: "events", field: "timestamp", order: "DESC"}
+				],
+				limit: 2
+			) {
+				timestamp
+			}
+		}`,
+		want: map[string]interface{}{
+			"events": []interface{}{
+				map[string]interface{}{
+					"timestamp": 1010,
+				},
+				map[string]interface{}{
+					"timestamp": 30,
+				},
+			},
+		},
+	},
 }
 
 func applySchemaOrDie(t *testing.T, bCtx *env.BubblyContext, s *Store, fromFile string) {

--- a/store/testdata/sqlgen/data8.hcl
+++ b/store/testdata/sqlgen/data8.hcl
@@ -1,0 +1,71 @@
+#
+# Data for tables8.hcl
+#
+
+# The Deep Dark Wood had been created in the beginning of time.
+# It has multiple events associated with it.
+data "location" {	
+	fields = {
+		"friendly_name": "Deep Dark Wood"
+		"created_at": 0
+	}
+}
+
+data "events" {
+	joins = [
+		"location",
+	]
+	fields = {
+		"severity": "INFO"
+		"timestamp": 10
+	}
+}
+
+data "events" {
+	joins = [
+		"location",
+	]
+	fields = {
+		"severity": "DEBUG"
+		"timestamp": 20
+	}
+}
+
+data "events" {
+	joins = [
+		"location",
+	]
+	fields = {
+		"severity": "CRITICAL"
+		"timestamp": 30
+	}
+}
+
+# Another location created much later...
+# It has only a single event associated with it.
+data "location" {
+	fields = {
+		"friendly_name": "Secret Underground Facility on the Moon"
+		"created_at": 1000
+	}
+}
+
+data "events" {
+	joins = [
+		"location",
+	]
+	fields = {
+		"severity": "DEBUG"
+		"timestamp": 1010
+	}
+}
+
+
+# Yet another location created last.
+# It has no events associated with it.
+data "location" {
+	fields = {
+		"friendly_name": "Gold Coast Villa"
+		"created_at": 2000
+	}
+}

--- a/store/testdata/sqlgen/tables8.hcl
+++ b/store/testdata/sqlgen/tables8.hcl
@@ -1,0 +1,28 @@
+#
+# Example for testing the GraphQL `limit` argument.
+#
+table "events" {
+
+	join "location" {}
+
+	field "severity" {
+		type = string
+	}
+
+	# UNIX epoch: https://www.epochconverter.com/
+	field "timestamp" {
+		type = number
+	}
+}
+
+table "location" {	
+	field "friendly_name" {
+		type = string
+		unique = true
+	}
+
+	# UNIX epoch: https://www.epochconverter.com/
+	field "created_at" {
+		type = string
+	}
+}


### PR DESCRIPTION
This is a first revision of `limit` argument support for GraphQL. My aim is to solve the issue @jlarfors is having with limiting the number of events requested. I've made an effort to keep the scope of change to the minimum.

The current implementation only supports `limit` on the root types.
If `order_by` is not specified as well, it is left to the database to decide which entries to return, which may not be what you expect.

@jlarfors would this solve the issue that you are having? If so, I recommend that we merge this, and then I can outline the solution for the more general case in a separate issue, and we can decide on its priority then as it would be a larger task.

Closes #90 