### PR TITLE
Avoid linking to external copy of license in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ TODO: this is in progress... Check back soon!
 
 ## Why Open Source?
 
-Bubbly is open source, licensed under the [Mozilla Public License v2](https://www.mozilla.org/en-US/MPL/2.0/).
+Bubbly is open source, licensed under the [Mozilla Public License v2](LICENSE).
 
 We have a few reasons for being open source:
 
@@ -105,4 +105,4 @@ See our [Contributing Guide](./docs/docs/contributing/contributing.md)
 
 ## License
 
-[Mozilla Public License Version 2.0](https://www.mozilla.org/en-US/MPL/)
+[Mozilla Public License Version 2.0](LICENSE)


### PR DESCRIPTION
Our README links to the copy of license stored on Mozilla's servers. I think we should link to our local copy of license and not depend on Mozilla not to change the license version or the URL to it.