### PR TITLE
Make `api_version` HCL attribute optional. Update docs and examples.

### DIFF
--- a/api/core/resource.go
+++ b/api/core/resource.go
@@ -31,7 +31,7 @@ type ResourceBlockHCLWrapper struct {
 type ResourceBlock struct {
 	ResourceKind       string            `hcl:",label" json:"kind" mapstructure:"kind"`
 	ResourceName       string            `hcl:",label" json:"name" mapstructure:"name"`
-	ResourceAPIVersion APIVersion        `hcl:"api_version,attr" json:"api_version" mapstructure:"api_version"`
+	ResourceAPIVersion APIVersion        `hcl:"api_version,optional" json:"api_version" mapstructure:"api_version"`
 	Metadata           *Metadata         `hcl:"metadata,block" json:"metadata" mapstructure:"metadata"`
 	SpecHCL            ResourceBlockSpec `hcl:"spec,block" json:"-"`
 }

--- a/docs/docs/introduction/core-concepts.md
+++ b/docs/docs/introduction/core-concepts.md
@@ -51,8 +51,6 @@ For example, an extraction of Github repository data from its GraphQL API:
 
 ```hcl
 resource "extract" "github_extract" {
-    api_version = "v1"
-    
     spec { 
         type = "graphql"
         source { 

--- a/docs/docs/resources/kinds.md
+++ b/docs/docs/resources/kinds.md
@@ -26,8 +26,6 @@ incomplete and is liable to change at any time.
 
 ```hcl
 resource "extract" "github_fork_count_extract" {
-	api_version = "v1"
-
 	spec {
 		type = "graphql"
 
@@ -175,8 +173,6 @@ Using the Bubbly Language this is as simple as:
 
 ```hcl
 resource "transform" "github_fork_count_transform" {
-	api_version = "v1"
-
 	spec {
 		input "data" {}
 
@@ -252,7 +248,6 @@ we define a `load` resource to _load_ this data to Bubbly like so:
 
 ```hcl
 resource "load" "github_fork_count_load" {
-	api_version = "v1"
 	spec {
 		input "data" {}
 		data = self.input.data
@@ -285,7 +280,6 @@ Bubbly Store for all repositories and their respective fork counts:
 
 ```hcl
 resource "query" "github_fork_count_query" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -358,7 +352,6 @@ to define the process of `extract -> transform -> load` as follows:
 
 ```hcl
 resource "pipeline" "github_fork_count_pipeline" {
-	api_version = "v1"
 	spec {
 		task "extract" {
 			resource = "extract/`github_fork_count_extract`"
@@ -429,7 +422,6 @@ repository fork count data, we define a `run` resource to run the `pipeline` res
 
 ```hcl
 resource "run" "github_fork_count_run" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/github_fork_count_pipeline"
 	}
@@ -475,7 +467,6 @@ the `bubbly` executable.
 
 ```hcl
 resource "run" "github_fork_count_run" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/github_fork_count_pipeline"
 	}
@@ -501,7 +492,6 @@ load the results of the run to the Bubbly Store, then end.
 
 ```hcl
 resource "run" "github_fork_count_run" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/github_fork_count_pipeline"
 	}
@@ -525,7 +515,6 @@ interval, loading the results of each interval run to the Bubbly Store
 
 ```hcl
 resource "run" "github_fork_count_run" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/github_fork_count_pipeline"
 	}
@@ -578,7 +567,6 @@ resource "extract" "sonarqube" {
       "environment": "prod"
     }
   }
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"
@@ -590,7 +578,6 @@ resource "extract" "sonarqube" {
 }
 
 resource "run" "sonarqube_remote" {
-  api_version = "v1"
   spec {
     remote {}
 

--- a/docs/docs/tutorials/github-metrics.md
+++ b/docs/docs/tutorials/github-metrics.md
@@ -102,8 +102,6 @@ Armed with this knowledge, you write your first definition of a Bubbly resource,
 #
 
 resource "extract" "repo_stats" {
-	api_version = "v1"
-
 	spec {
 		type = "graphql"
 
@@ -163,7 +161,7 @@ This Bubbly file is written in standard HCL, using the notation understood by th
 
 :::caution TODO
 
-This is standard HCL, api_version, spec block for different types of extract, each extract type has different options , bearer token in env variable, graphql query as HCL heredoc, format is HCL type expression (link to detailed guide), mention objects and strings, numbers, {} is map syntax because even format = ... is valid HCL.
+This is standard HCL, spec block for different types of extract, each extract type has different options , bearer token in env variable, graphql query as HCL heredoc, format is HCL type expression (link to detailed guide), mention objects and strings, numbers, {} is map syntax because even format = ... is valid HCL.
 
 ../resources/kinds.md#extract provides the spec for the different source types. We definitely need to provide a detailed guide for the format attribute. I suggest adding an admonition stating this is under construction and a full explanation for the format attribute used in extract/repo_stats for this tutorial is coming soon.
 
@@ -248,8 +246,6 @@ A `transform` is just another kind of resource, so you add the following definit
 # ...
 
 resource "transform" "repo_stats" {
-	api_version = "v1"
-
 	spec {
 		input "data" {}
 
@@ -293,7 +289,6 @@ After the data has been extracted from Github via the `extract/repo_stats` resou
 # ...
 
 resource "load" "repo_stats" {
-	api_version = "v1"
 	spec {
 		input "data" {}
 		data = self.input.data
@@ -341,8 +336,6 @@ The various parts of the pipeline that you have already defined all come togethe
 # ... extract/transform/load definitions first ...
 
 resource "pipeline" "repo_stats" {
-	api_version = "v1"
-
 	spec {
 
 		task "extract" {
@@ -381,7 +374,6 @@ To tie it all together, you add a `run` resource, whose purpose (as its resource
 # ... pipeline definitions next ...
 
 resource "run" "repo_stats" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/repo_stats"
 	}

--- a/docs/docs/tutorials/gosec-metrics.md
+++ b/docs/docs/tutorials/gosec-metrics.md
@@ -75,7 +75,6 @@ Here, we will simply extract just the severity from the issues.
 
 ```hcl
 resource "extract" "gosec" {
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"
@@ -97,7 +96,6 @@ Now that we have the severity, it is time to transform it into a format that `Bu
 
 ```hcl
 resource "transform" "gosec" {
-  api_version = "v1"
   spec {
     input "data" {}
     dynamic "data" {
@@ -120,7 +118,6 @@ The next step is to load the data!
 
 ```hcl
 resource "load" "gosec" {
-  api_version = "v1"
   spec {
     input "data" {}
     data = self.input.data
@@ -134,7 +131,6 @@ In this step, we will stitch all the data together in a single pipeline.
 
 ```hcl
 resource "pipeline" "gosec" {
-  api_version = "v1"
   spec {
     input "gosec_results" {
       default = "./testdata/gosec/results.json"
@@ -167,7 +163,6 @@ Next, we will add a simple `run` resource for the pipeline.
 
 ```hcl
 resource "run" "gosec" {
-  api_version = "v1"
   spec {
     resource = "pipeline/gosec"
   }
@@ -181,7 +176,6 @@ reflect the location of the file you are looking to upload.
 
 ```hcl
 resource "run" "gosec/extract" {
-  api_version = "v1"
   spec {
     resource = "extract/gosec"
     input "file" {
@@ -198,7 +192,6 @@ issue.
 
 ```hcl
 resource "query" "gosec_data" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -217,7 +210,6 @@ Here, we will write a quick criteria, that will pass on the condition that there
 
 ```hcl
 resource "criteria" "gosec_status" {
-  api_version = "v1"
   spec {
     query "gosec_data" {}
     condition "no_high" {
@@ -237,7 +229,6 @@ The final step is to just write a `run` resource for the criteria as follows.
 
 ```hcl
 resource "run" "gosec_criteria" {
-  api_version = "v1"
   spec {
     resource = "criteria/gosec_status"
   }

--- a/docs/docs/tutorials/snyk-metrics.md
+++ b/docs/docs/tutorials/snyk-metrics.md
@@ -146,7 +146,6 @@ file
 
 ```hcl
 resource "extract" "snyk" {
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"
@@ -181,7 +180,6 @@ json) to a format that matches the `Bubbly Schema`.
 
 ```hcl
 resource "transform" "snyk" {
-  api_version = "v1"
   spec {
     input "data" {}
 
@@ -213,7 +211,6 @@ Now that our data has been transformed, the next step, is to `load` the data int
 
 ```hcl
 resource "load" "snyk" {
-  api_version = "v1"
   spec {
     input "data" {}
     data = self.input.data
@@ -229,7 +226,6 @@ together the earlier phases into one coherent place.
 
 ```hcl
 resource "pipeline" "snyk" {
-  api_version = "v1"
   spec {
     input "snyk_file" {
       default = "./testdata/snyk/snyk.json"
@@ -262,7 +258,6 @@ Now that the pipeline is in place, we need to inform the `API` that we want to r
 
 ```hcl
 resource "run" "snyk" {
-  api_version = "v1"
   spec {
     resource = "pipeline/snyk"
   }
@@ -273,7 +268,6 @@ resource "run" "snyk" {
 
 ```hcl
 resource "run" "sonarqube/extract" {
-  api_version = "v1"
   spec {
     resource = "extract/snyk"
     input "file" {
@@ -291,7 +285,6 @@ quick query using `Graphql` to fetch the severity of the vulnerabilities.
 
 ```hcl
 resource "query" "snyk_data" {
-  api_version = "v1"
   spec {
     query = <<EOT
             {
@@ -311,7 +304,6 @@ ensure this.
 
 ```hcl
 resource "criteria" "snyk_status" {
-  api_version = "v1"
   spec {
     query "snyk_data" {}
     condition "no_high" {
@@ -331,7 +323,6 @@ The final step, is simply to provide a `run resource` to inform `Bubbly` that it
 
 ```hcl
 resource "run" "snyk_criteria" {
-  api_version = "v1"
   spec {
     resource = "criteria/snyk_status"
   }

--- a/docs/docs/tutorials/tutorial1.bubbly
+++ b/docs/docs/tutorials/tutorial1.bubbly
@@ -7,7 +7,6 @@
 #
 
 resource "extract" "repo_stats" {
-	api_version = "v1"
 
 	spec {
 		type = "graphql"
@@ -60,7 +59,6 @@ resource "extract" "repo_stats" {
 }
 
 resource "transform" "repo_stats" {
-	api_version = "v1"
 
 	spec {
 		input "data" {}
@@ -83,7 +81,6 @@ resource "transform" "repo_stats" {
 }
 
 resource "load" "repo_stats" {
-	api_version = "v1"
 	spec {
 		input "data" {}
 		data = self.input.data
@@ -91,7 +88,6 @@ resource "load" "repo_stats" {
 }
 
 resource "pipeline" "repo_stats" {
-	api_version = "v1"
 	spec {
 		task "extract" {
 			resource = "extract/repo_stats"
@@ -112,7 +108,6 @@ resource "pipeline" "repo_stats" {
 }
 
 resource "run" "repo_stats" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/repo_stats"
 	}

--- a/integration/testdata/gosec/gosec.bubbly
+++ b/integration/testdata/gosec/gosec.bubbly
@@ -1,5 +1,4 @@
 resource "extract" "gosec" {
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"
@@ -21,7 +20,6 @@ resource "extract" "gosec" {
 }
 
 resource "transform" "gosec" {
-  api_version = "v1"
   spec {
     input "data" {}
     dynamic "data" {
@@ -44,7 +42,6 @@ resource "transform" "gosec" {
 }
 
 resource "load" "gosec" {
-  api_version = "v1"
   spec {
     input "data" {}
     data = self.input.data
@@ -52,7 +49,6 @@ resource "load" "gosec" {
 }
 
 resource "pipeline" "gosec" {
-  api_version = "v1"
   spec {
     input "gosec_results" {
       default = "./testdata/gosec/results.json"
@@ -80,7 +76,6 @@ resource "pipeline" "gosec" {
 
 
 resource "run" "gosec" {
-  api_version = "v1"
   spec {
     resource = "pipeline/gosec"
   }
@@ -88,7 +83,6 @@ resource "run" "gosec" {
 
 
 resource "run" "gosec/extract" {
-  api_version = "v1"
   spec {
     resource = "extract/gosec"
     input "file" {
@@ -98,7 +92,6 @@ resource "run" "gosec/extract" {
 }
 
 resource "query" "gosec_data" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -111,7 +104,6 @@ resource "query" "gosec_data" {
 }
 
 resource "criteria" "gosec_status" {
-  api_version = "v1"
   spec {
     query "gosec_data" {}
     condition "no_high" {
@@ -125,7 +117,6 @@ resource "criteria" "gosec_status" {
 }
 
 resource "run" "gosec_criteria" {
-  api_version = "v1"
   spec {
     resource = "criteria/gosec_status"
   }

--- a/integration/testdata/junit/junit-pipeline.bubbly
+++ b/integration/testdata/junit/junit-pipeline.bubbly
@@ -5,7 +5,6 @@
 //   - status: sucess
 //   - value: <the value from the extract>
 resource "extract" "junit" {
-    api_version = "v1"
     // this is an input to the extract to make it reusable
     spec {
         input "file" {}
@@ -34,7 +33,6 @@ resource "extract" "junit" {
 }
 
 resource "transform" "junit" {
-    api_version = "v1"
     spec {
         input "data" {}
         // this is some crazy dynamic HCL stuff to create the "data" blocks
@@ -54,7 +52,6 @@ resource "transform" "junit" {
 
 // This is the upload step, just renamed to load...
 resource "load" "junit" {
-    api_version = "v1"
     spec {
         input "data" {}
         // what do we need here?!
@@ -66,7 +63,6 @@ resource "load" "junit" {
 // A pipeline is just another reusable resource, and only a pipelineRun
 // actually triggers a pipeline to run
 resource "pipeline" "junit" {
-    api_version = "v1"
     spec {
         input "file" {}
         // Each task in a pipeline has an output, similar to resources,
@@ -94,7 +90,6 @@ resource "pipeline" "junit" {
 }
 
 resource "run" "junit" {
-    api_version = "v1"
     spec {
         // specify the name of the pipeline resource to execute
         resource = "junit"

--- a/integration/testdata/resources/v1/criteria/criteria.bubbly
+++ b/integration/testdata/resources/v1/criteria/criteria.bubbly
@@ -1,5 +1,4 @@
 resource "query" "shakespeare_quote" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -16,7 +15,6 @@ resource "query" "shakespeare_quote" {
 // Evaluation of these operations yields a boolean return value representing
 // success or failure of the criteria.
 resource "criteria" "shakespeare" {
-  api_version = "v1"
   spec {
     query "shakespeare_quote" {}
     condition "a" {
@@ -44,7 +42,6 @@ resource "criteria" "shakespeare" {
 }
 
 resource "run" "shakespeare_criteria" {
-  api_version = "v1"
   spec {
     resource = "criteria/shakespeare"
   }

--- a/integration/testdata/resources/v1/extract/graphql/download-count.bubbly
+++ b/integration/testdata/resources/v1/extract/graphql/download-count.bubbly
@@ -15,7 +15,6 @@
 #
 
 resource "extract" "e1" {
-	api_version = "v1"
 
 	spec {
 		type = "graphql"
@@ -139,7 +138,6 @@ resource "extract" "e1" {
 }
 
 resource "transform" "t1" {
-	api_version = "v1"
 
 	spec {
 		input "data" {}
@@ -207,7 +205,6 @@ resource "transform" "t1" {
 }
 
 resource "load" "l1" {
-	api_version = "v1"
 	spec {
 		input "data" {}
 		data = self.input.data
@@ -215,7 +212,6 @@ resource "load" "l1" {
 }
 
 resource "pipeline" "p1" {
-	api_version = "v1"
 	spec {
 		task "extract" {
 			resource = "extract/e1"
@@ -236,7 +232,6 @@ resource "pipeline" "p1" {
 }
 
 resource "run" "pr1" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/p1"
 	}

--- a/integration/testdata/resources/v1/extract/graphql/github.bubbly
+++ b/integration/testdata/resources/v1/extract/graphql/github.bubbly
@@ -12,7 +12,6 @@
 #
 
 resource "extract" "bubbly_repo" {
-	api_version = "v1"
 
 	spec {
 		type = "graphql"
@@ -100,7 +99,6 @@ resource "extract" "bubbly_repo" {
 }
 
 resource "transform" "bubbly_repo" {
-	api_version = "v1"
 
 	spec {
 		input "data" {}
@@ -155,7 +153,6 @@ resource "transform" "bubbly_repo" {
 }
 
 resource "load" "bubbly_repo" {
-	api_version = "v1"
 	spec {
 		input "data" {}
 		data = self.input.data
@@ -163,7 +160,6 @@ resource "load" "bubbly_repo" {
 }
 
 resource "pipeline" "bubbly_repo" {
-	api_version = "v1"
 
 	spec {
 		task "extract" {
@@ -185,7 +181,6 @@ resource "pipeline" "bubbly_repo" {
 }
 
 resource "run" "bubbly_repo" {
-	api_version = "v1"
 	spec {
 		resource = "pipeline/bubbly_repo"
 	}

--- a/integration/testdata/resources/v1/extract/spdx-licenses.bubbly
+++ b/integration/testdata/resources/v1/extract/spdx-licenses.bubbly
@@ -1,6 +1,4 @@
 resource "extract" "spdx_list" {
-    api_version = "v1"
-
     spec {
         input url {}
         type = "rest"
@@ -33,8 +31,6 @@ resource "extract" "spdx_list" {
 }
 
 resource "extract" "spdx_licenses" {
-    api_version = "v1"
-    
     spec {
         input spdx_list {}
         type = "rest"
@@ -77,8 +73,6 @@ resource "extract" "spdx_licenses" {
 }
 
 resource "transform" "license_data" {
-    api_version = "v1"
-
     spec {
         input "spdx_licenses" {}
 
@@ -105,8 +99,6 @@ resource "transform" "license_data" {
 }
 
 resource "load" "upload_license_data" {
-    api_version = "v1"
-
     spec {
         input "data" {}
         data = self.input.data
@@ -114,8 +106,6 @@ resource "load" "upload_license_data" {
 }
 
 resource "pipeline" "licenses" {
-    api_version = "v1"
-
     spec {
 
         task "extract_spdx_list" {
@@ -150,7 +140,6 @@ resource "pipeline" "licenses" {
 }
 
 resource "run" "licenses" {
-    api_version = "v1"
     spec {
         resource = "pipeline/licenses"
     }

--- a/integration/testdata/resources/v1/extract/tempo.bubbly
+++ b/integration/testdata/resources/v1/extract/tempo.bubbly
@@ -36,7 +36,6 @@
 #
 
 resource "extract" "account_id" {
-    api_version = "v1"
 
     spec {
         type = "rest"
@@ -76,7 +75,6 @@ resource "extract" "account_id" {
 # Retrieve from Tempo the list of exact start/end dates for each period,
 # defined by the environmental variables TEMPO_FROM and TEMPO_TO
 resource "extract" "periods" {
-    api_version = "v1"
 
     spec {
         type = "rest"
@@ -108,7 +106,6 @@ resource "extract" "periods" {
 # we already come knowing `accountId` value which we had acquired in `extract/account_id`
 # using a different API (using Jira API, not Tempo's).
 resource "extract" "timesheet_approvals" {
-    api_version = "v1"
     
     spec {
         input account {}
@@ -145,7 +142,6 @@ resource "extract" "timesheet_approvals" {
 }
 
 resource "transform" "compute" {
-    api_version = "v1"
     spec {
         input "timesheet_approvals" {}
         dynamic "data" {
@@ -165,7 +161,6 @@ resource "transform" "compute" {
 }
 
 resource "load" "l1" {
-    api_version = "v1"
     spec {
         input "data" {}
         data = self.input.data
@@ -173,7 +168,6 @@ resource "load" "l1" {
 }
 
 resource "pipeline" "tempo_timesheet" {
-    api_version = "v1"
 
     spec {
         task "extract_account_id" {
@@ -207,7 +201,6 @@ resource "pipeline" "tempo_timesheet" {
 }
 
 resource "pipeline_run" "tempo_timesheet" {
-    api_version = "v1"
     spec {
         #interval = "6h"
         pipeline = "pipeline/tempo_timesheet"

--- a/integration/testdata/resources/v1/query/query.bubbly
+++ b/integration/testdata/resources/v1/query/query.bubbly
@@ -1,7 +1,6 @@
 //  defines a data source and a format for the data, and returns a cty.Value
 // representation of the external data.
 resource "query" "golang_unit" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -31,7 +30,6 @@ resource "query" "golang_unit" {
 }
 
 resource "run" "golang_query" {
-  api_version = "v1"
   spec {
     resource = "query/golang_unit"
   }

--- a/integration/testdata/resources/v1/run/remote_resources.bubbly
+++ b/integration/testdata/resources/v1/run/remote_resources.bubbly
@@ -1,5 +1,4 @@
 resource "extract" "spdx_list" {
-  api_version = "v1"
 
   spec {
     input url {}
@@ -32,8 +31,7 @@ resource "extract" "spdx_list" {
 }
 
 resource "pipeline" "licenses" {
-  api_version = "v1"
-
+  
   spec {
 
     task "extract_spdx_list" {
@@ -47,7 +45,7 @@ resource "pipeline" "licenses" {
 }
 
 resource "run" "licenses_remote" {
-  api_version = "v1"
+
   spec {
     resource = "pipeline/licenses"
 

--- a/integration/testdata/resources/v1/run/remote_run_with_remote_input.bubbly
+++ b/integration/testdata/resources/v1/run/remote_run_with_remote_input.bubbly
@@ -6,7 +6,6 @@ resource "extract" "sonarqube" {
       "environment": "prod"
     }
   }
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"
@@ -35,7 +34,6 @@ resource "extract" "sonarqube" {
 }
 
 resource "run" "sonarqube_remote" {
-  api_version = "v1"
   spec {
     remote {}
 

--- a/integration/testdata/resources/v1/run/resources.bubbly
+++ b/integration/testdata/resources/v1/run/resources.bubbly
@@ -7,7 +7,6 @@ resource "extract" "sonarqube" {
             "environment": "prod"
         }
     }
-    api_version = "v1"
     spec {
         input "file" {}
         type = "json"
@@ -37,7 +36,6 @@ resource "extract" "sonarqube" {
 
 
 resource "run" "extract_sonarqube" {
-  api_version = "v1"
   spec {
     resource = "extract/sonarqube"
     input "file" {

--- a/integration/testdata/snyk/snyk-pipeline.bubbly
+++ b/integration/testdata/snyk/snyk-pipeline.bubbly
@@ -1,5 +1,4 @@
 resource "extract" "snyk" {
-    api_version = "v1"
     spec {
         input "file" { }
         type = "json"
@@ -54,7 +53,6 @@ resource "extract" "snyk" {
 }
 
 resource "transform" "snyk" {
-    api_version = "v1"
     spec {
         input "data" {}
 
@@ -79,7 +77,6 @@ resource "transform" "snyk" {
 }
 
 resource "load" "snyk" {
-    api_version = "v1"
     spec {
         input "data" {}
         data = self.input.data
@@ -87,7 +84,6 @@ resource "load" "snyk" {
 }
 
 resource "pipeline" "snyk" {
-    api_version = "v1"
     spec {
         input "whatever" {
             default = "./testdata/snyk/test.json"
@@ -114,14 +110,12 @@ resource "pipeline" "snyk" {
 }
 
 resource "run" "snyk" {
-    api_version = "v1"
     spec {
         resource = "pipeline/snyk"
     }
 }
 
 resource "run" "snyk_extract" {
-    api_version = "v1"
     spec {
         resource = "extract/snyk"
         input "file" {
@@ -131,7 +125,6 @@ resource "run" "snyk_extract" {
 }
 
 resource "query" "snyk_data" {
-    api_version = "v1"
     spec {
         query = <<EOT
             {
@@ -145,7 +138,6 @@ resource "query" "snyk_data" {
 
 
 resource "criteria" "snyk_status" {
-    api_version = "v1"
     spec {
         query "snyk_data" {}
         condition "no_high" {
@@ -159,7 +151,6 @@ resource "criteria" "snyk_status" {
 }
 
 resource "run" "snyk_criteria" {
-    api_version = "v1"
     spec {
         resource = "criteria/snyk_status"
     }

--- a/integration/testdata/sonarqube/sonarqube-pipeline.bubbly
+++ b/integration/testdata/sonarqube/sonarqube-pipeline.bubbly
@@ -7,7 +7,6 @@ resource "extract" "sonarqube" {
             "environment": "prod"
         }
     }
-    api_version = "v1"
     spec {
         input "file" {}
         type = "json"
@@ -36,7 +35,6 @@ resource "extract" "sonarqube" {
 }
 
 resource "extract" "git" {
-    api_version = "v1"
     metadata {
         labels = {
             "environment": "prod"
@@ -56,7 +54,6 @@ resource "extract" "git" {
 // defines a transformation or conversion of data from an Extract and outputs
 // a mapping of the extracted data to the defined data schema.
 resource "transform" "sonarqube" {
-    api_version = "v1"
     metadata {
         labels = {
             "environment": "prod"
@@ -107,7 +104,6 @@ resource "load" "sonarqube" {
             "environment": "prod"
         }
     }
-    api_version = "v1"
     spec {
         input "data" {}
         // what do we need here?!
@@ -124,7 +120,6 @@ resource "pipeline" "sonarqube" {
             "environment": "prod"
         }
     }
-    api_version = "v1"
     spec {
         input "file" {}
         input "repo" {}
@@ -174,7 +169,6 @@ resource "pipeline" "sonarqube" {
 
 // A run resource runs a resource.
 resource "run" "sonarqube_pipeline" {
-    api_version = "v1"
     metadata {
         labels = {
             "environment": "prod"
@@ -196,7 +190,6 @@ resource "run" "sonarqube_pipeline" {
 
 // Run the extract resource
 resource "run" "sonarqube_extract" {
-    api_version = "v1"
     metadata {
         labels = {}
     }

--- a/integration/testdata/testautomation/golang/pipeline.bubbly
+++ b/integration/testdata/testautomation/golang/pipeline.bubbly
@@ -1,6 +1,5 @@
 
 resource "extract" "gotest" {
-    api_version = "v1"
     // this is an input to the extract to make it reusable
     spec {
         input "file" {}
@@ -21,7 +20,6 @@ resource "extract" "gotest" {
 }
 
 resource "transform" "gotest" {
-    api_version = "v1"
     spec {
         input "data" {}
 
@@ -62,7 +60,6 @@ resource "transform" "gotest" {
 }
 
 resource "load" "gotest" {
-    api_version = "v1"
     spec {
         input "data" {}
         data = self.input.data
@@ -70,7 +67,6 @@ resource "load" "gotest" {
 }
 
 resource "pipeline" "gotest" {
-    api_version = "v1"
     spec {
         input "file" {}
         // Each task in a pipeline has an output, similar to resources,
@@ -97,7 +93,6 @@ resource "pipeline" "gotest" {
 }
 
 resource "run" "gotest" {
-    api_version = "v1"
     spec {
         // specify the name of the pipeline resource to execute
         resource = "pipeline/gotest"

--- a/integration/testdata/testautomation/golang/query.bubbly
+++ b/integration/testdata/testautomation/golang/query.bubbly
@@ -1,5 +1,4 @@
 resource "query" "go" {
-  api_version = "v1"
   spec {
     query = <<EOT
       {
@@ -13,7 +12,6 @@ resource "query" "go" {
 }
 
 resource "run" "go_query" {
-  api_version = "v1"
   spec {
     resource = "query/go"
   }

--- a/interval/testdata/extract.bubbly
+++ b/interval/testdata/extract.bubbly
@@ -7,7 +7,6 @@ resource "extract" "sonarqube" {
       "environment": "prod"
     }
   }
-  api_version = "v1"
   spec {
     input "file" {}
     type = "json"

--- a/interval/testdata/run_local.bubbly
+++ b/interval/testdata/run_local.bubbly
@@ -1,6 +1,5 @@
 // Run the extract resource
 resource "run" "sonarqube_extract" {
-  api_version = "v1"
   metadata {
     labels = {}
   }

--- a/interval/testdata/run_remote_interval.bubbly
+++ b/interval/testdata/run_remote_interval.bubbly
@@ -1,6 +1,5 @@
 // Run the extract resource
 resource "run" "sonarqube_extract" {
-  api_version = "v1"
   metadata {
     labels = {}
   }

--- a/interval/testdata/run_remote_one_off.bubbly
+++ b/interval/testdata/run_remote_one_off.bubbly
@@ -1,6 +1,5 @@
 // Run the extract resource
 resource "run" "sonarqube_extract" {
-  api_version = "v1"
   metadata {
     labels = {}
   }


### PR DESCRIPTION
* Literally, a _one-liner_, making the `api_version` attribute optional. 
* The rest is updates to the docs and examples.

Closes #52 