### PR TITLE
Add Docker image build and push to `goreleaser`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # ignore folders
 .git
 build
+dist
 kubernetes
 
 # ignore config files that are not required

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 *.so
 *.dylib
 
-# Build directory
+# Build directories
 build/
+dist/
 
 # Test binary, built with `go test -c`
 *.test
@@ -34,4 +35,7 @@ dataaccess/*.db
 node_modules
 
 .idea
-dist/
+
+# Swagger auto-generated
+docs/swagger.json
+docs/swagger.yaml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
       - -s -w -X main.VERSION={{ .Version }}
     env:
       - CGO_ENABLED=0
+    hooks:
+      pre: swag init
     id: linux
     goos:
       - linux
@@ -48,6 +50,20 @@ brews:
     description: "Bubbly CLI"
     test: |
       system "#{bin}/bubbly --version"
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    skip_push: auto
+    use_buildx: true
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+    - "valocode/{{ .ProjectName }}:latest"
+    - "valocode/{{ .ProjectName }}:{{ .Tag }}"
+    - "valocode/{{ .ProjectName }}:{{ .Major }}"
+    - "valocode/{{ .ProjectName }}:{{ .Major }}{{ .Minor }}"
+    build_flag_templates:
+    - "--pull"
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,16 @@
+# This Dockerfile is written for use with goreleaser
+FROM gcr.io/distroless/base-debian10
+
+# Copy the static executable built by goreleaser
+COPY bubbly /bubbly
+
+# Bubbly makes use of these TCP ports:
+#   4223 NATS service
+#   8111 bubbly agent
+#   8222 NATS HTTP
+EXPOSE 4223 8111 8222
+
+# Run as unprivileged user
+USER nonroot:nonroot
+
+ENTRYPOINT ["/bubbly"]


### PR DESCRIPTION
This PR updates our `goreleaser` configuration and the `Dockerfile` to build and push the Docker image to the Docker Hub.

Closes #89 