### PR TITLE
fix: add a hook to `goreleaser` to install `swag` before starting a build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 project_name: bubbly
+before:
+  hooks:
+  - go get -u github.com/swaggo/swag/cmd/swag
 builds:
   - binary: bubbly
     main: main.go


### PR DESCRIPTION
Add a global hook to `goreleaser` to install `swag` before attempting to build.
This is because the `goreleaser` runs `swag init` in order to be able to build the Docker images.
Because `goreleaser` has its own view of what goes inside a Docker image 🙃 