### PR TITLE
fix: login to Docker Hub before releasing images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Wouldn't it be nice, if I also logged into Docker Hub before attempting to push images to it?! 🙄 