### PR TITLE
Fix duplicate StoreConfig in AgentConfig. Cleanup CLI color use

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -11,16 +11,14 @@ import (
 	"github.com/valocode/bubbly/config"
 	"github.com/valocode/bubbly/env"
 
-	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
 
-	"github.com/valocode/bubbly/cmd/util"
 	cmdutil "github.com/valocode/bubbly/cmd/util"
 )
 
 var (
 	_         cmdutil.Options = (*AgentOptions)(nil)
-	agentLong                 = util.LongDesc(
+	agentLong                 = cmdutil.LongDesc(
 		`
 		Starts a bubbly agent. The agent can be configured to run all components, or only some subset, 
 		depending on the flags provided.
@@ -31,7 +29,7 @@ var (
 		`,
 	)
 
-	agentExample = util.Examples(
+	agentExample = cmdutil.Examples(
 		`
 		# Starts the bubbly agent with all components (API Server, NATS Server, Store and Worker) 
 		using application defaults
@@ -81,7 +79,7 @@ func NewCmdAgent(bCtx *env.BubblyContext) (*cobra.Command, *AgentOptions) {
 			bCtx.Logger.Debug().
 				Interface(
 					"data_store",
-					o.bCtx.AgentConfig.StoreConfig,
+					bCtx.StoreConfig,
 				).
 				Interface(
 					"nats_server",
@@ -104,19 +102,6 @@ func NewCmdAgent(bCtx *env.BubblyContext) (*cobra.Command, *AgentOptions) {
 			}
 
 			o.Print()
-			return nil
-		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// prior to running the agent, we merge defaults with the
-			// config provided by command flags to make sure
-			// we have a complete configuration
-			if err := mergo.Merge(
-				o.bCtx.AgentConfig,
-				config.DefaultAgentConfig(),
-			); err != nil {
-				return fmt.Errorf("error merging agent configuration with defaults: %w", err)
-			}
-
 			return nil
 		},
 	}
@@ -156,7 +141,7 @@ func NewCmdAgent(bCtx *env.BubblyContext) (*cobra.Command, *AgentOptions) {
 		"whether to run a bubbly worker on this agent",
 	)
 	f.StringVar(
-		(*string)(&o.bCtx.AgentConfig.StoreConfig.Provider),
+		(*string)(&o.bCtx.StoreConfig.Provider),
 		"data-store-provider",
 		config.DefaultStoreProvider,
 		"provider of the bubbly data store",
@@ -176,28 +161,28 @@ func NewCmdAgent(bCtx *env.BubblyContext) (*cobra.Command, *AgentOptions) {
 		"HTTP Port of the NATS Server",
 	)
 	f.StringVar(
-		&o.bCtx.AgentConfig.StoreConfig.PostgresAddr,
-		"data-store-addr",
+		&o.bCtx.StoreConfig.PostgresAddr,
+		"postgres-addr",
 		config.DefaultPostgresAddr,
-		"address of the data store",
+		"postgres address for the data store",
 	)
 	f.StringVar(
-		&o.bCtx.AgentConfig.StoreConfig.PostgresUser,
-		"data-store-username",
+		&o.bCtx.StoreConfig.PostgresUser,
+		"postgres-username",
 		config.DefaultPostgresUser,
-		"username of the data store",
+		"postgres username for the data store",
 	)
 	f.StringVar(
-		&o.bCtx.AgentConfig.StoreConfig.PostgresPassword,
-		"data-store-password",
+		&o.bCtx.StoreConfig.PostgresPassword,
+		"postgres-password",
 		config.DefaultPostgresPassword,
-		"password of the data store",
+		"postgres password for the data store",
 	)
 	f.StringVar(
-		&o.bCtx.AgentConfig.StoreConfig.PostgresDatabase,
-		"data-store-database",
+		&o.bCtx.StoreConfig.PostgresDatabase,
+		"postgres-database",
 		config.DefaultPostgresDatabase,
-		"database of the data store",
+		"postgres database for the data store",
 	)
 
 	return cmd, o

--- a/cmd/release/create/create.go
+++ b/cmd/release/create/create.go
@@ -96,7 +96,11 @@ func (o *options) run() error {
 
 // Print prints the successful outcome of the cmd
 func (o *options) Print() {
-	color.Green("Release successfully created!")
+	if o.bCtx.CLIConfig.Color {
+		color.Green("Release successfully created!")
+	} else {
+		fmt.Println("Release successfully created!")
+	}
 
 	fmt.Println("\n" + o.Release.String())
 }

--- a/cmd/release/eval/eval.go
+++ b/cmd/release/eval/eval.go
@@ -1,6 +1,8 @@
 package list
 
 import (
+	"fmt"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
@@ -99,7 +101,9 @@ func (o *options) run() error {
 
 // Print prints the successful outcome of the cmd
 func (o *options) Print() {
-	color.Green("Release entry successfully logged!")
-
-	// fmt.Println("\n" + o.Release.String())
+	if o.bCtx.CLIConfig.Color {
+		color.Green("Release entry successfully logged!")
+	} else {
+		fmt.Println("Release entry successfully logged!")
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,6 @@ func (a AgentDeploymentType) String() string {
 
 // AgentConfig stores the configuration of a bubbly agent
 type AgentConfig struct {
-	StoreConfig       *StoreConfig
 	NATSServerConfig  *NATSServerConfig
 	EnabledComponents *AgentComponentsToggle
 	DeploymentType    AgentDeploymentType

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -111,7 +111,6 @@ func DefaultStoreConfig() *StoreConfig {
 // or, preferentially, from provided environment variables.
 func DefaultAgentConfig() *AgentConfig {
 	return &AgentConfig{
-		StoreConfig:       DefaultStoreConfig(),
 		NATSServerConfig:  DefaultNATSServerConfig(),
 		EnabledComponents: DefaultAgentComponentsEnabled(),
 		DeploymentType:    AgentDeploymentType(defaultEnv("AGENT_DEPLOYMENT_TYPE", DefaultDeploymentType.String())),

--- a/main.go
+++ b/main.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/valocode/bubbly/docs"
 
-	"github.com/imdario/mergo"
-
 	"github.com/rs/zerolog"
 	"github.com/valocode/bubbly/cmd"
 	"github.com/valocode/bubbly/config"
@@ -68,17 +66,6 @@ func main() {
 			).
 				Msg("updated log level")
 		}
-	}
-
-	// Because several of rootCmd's flags are mapped to BubblyContext.Config
-	// attributes (and therefore reset when calling NewCmdRoot),
-	// we need to merge the default configuration with any flags
-	// provided by CLI.
-	defaultConfig := config.DefaultServerConfig()
-
-	if err := mergo.Merge(bCtx.ServerConfig, defaultConfig); err != nil {
-		bCtx.Logger.Error().Err(err).Msg("error when merging configs")
-		os.Exit(1)
 	}
 
 	// finally, print the final configuration to be used by bubbly


### PR DESCRIPTION
This fixes the situation with CLI options not being used with the store. And as you can see there was a pretty heinous error in there (duplicate `StoreConfig` in `AgentConfig`).

I also removed the use of `mergo` for the CLI, because `env.NewBubblyContext()` sets all defaults anyway... so we already start with a default config that reads env variables. Then we are just updating that instance of `BubblyContext` with any flags from the CLI.
So to me, the use of `mergo` is redundant now. But I could be wrong :)